### PR TITLE
Fix duplicated thread method declarations

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -79,18 +79,6 @@ export interface IStorage {
   ): Promise<MessageThread>;
   addMessageToThread(threadId: number, message: InsertMessage): Promise<Message>;
   markThreadAsRead(threadId: number): Promise<boolean>;
-  getThreadMessages(threadId: number): Promise<MessageType[]>;
-  createThread(thread: InsertMessageThread): Promise<MessageThread>;
-  updateThread(id: number, updates: Partial<MessageThread>): Promise<MessageThread | undefined>;
-  findOrCreateThreadByParticipant(
-    userId: number, 
-    externalParticipantId: string, 
-    participantName: string, 
-    source: string,
-    participantAvatar?: string
-  ): Promise<MessageThread>;
-  addMessageToThread(threadId: number, message: InsertMessage): Promise<Message>;
-  markThreadAsRead(threadId: number): Promise<boolean>;
 }
 
 export class MemStorage implements IStorage {


### PR DESCRIPTION
## Summary
- remove repeated thread methods in `IStorage` interface

## Testing
- `npm run check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a14662d0833380b69500902aed22