### PR TITLE
Add missing apiRequest helper

### DIFF
--- a/server/utils/apiUtils.ts
+++ b/server/utils/apiUtils.ts
@@ -1,0 +1,14 @@
+export async function apiRequest(method: string, url: string, data?: unknown): Promise<Response> {
+  const res = await fetch(url, {
+    method,
+    headers: data ? { "Content-Type": "application/json" } : {},
+    body: data ? JSON.stringify(data) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = (await res.text()) || res.statusText;
+    throw new Error(`${res.status}: ${text}`);
+  }
+
+  return res;
+}


### PR DESCRIPTION
## Summary
- add a simple fetch-based `apiRequest` helper under `server/utils`

## Testing
- `npm run check` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844a138a87483338e35b7ad82ae4e7a