### PR TITLE
Fix conversation threading in memory mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## 2025-06-07
 - [Added] Created `CHANGELOG.md` and added contribution instructions to `README.md`.
+
+## 2025-06-08
+- [Fixed] Missing `parentMessageId` from in-memory storage caused replies to show as top-level messages.

--- a/server/services/content.ts
+++ b/server/services/content.ts
@@ -8,6 +8,7 @@ import { storage } from "../storage";
 import { aiService } from "./openai";
 import { eq, desc } from "drizzle-orm";
 import { contentItems, type InsertContentItem } from "@shared/schema";
+import { log } from "../logger";
 
 interface ContentSource {
   id: string;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -366,6 +366,17 @@ export class MemStorage {
       avatar: msg.senderAvatar ?? undefined
     };
 
+    // Normalize parent ID to avoid threading issues when running without the
+    // database. Missing parentMessageId was causing replies to render as
+    // top-level messages. Ref: [Fixed] 2025-06-08 in CHANGELOG.md
+    let parentId: number | undefined = undefined;
+    if (msg.parentMessageId !== undefined && msg.parentMessageId !== null) {
+      const numeric = Number(msg.parentMessageId);
+      if (!Number.isNaN(numeric)) {
+        parentId = numeric;
+      }
+    }
+
     return {
       id: msg.id,
       source: msg.source as 'instagram' | 'youtube',
@@ -375,7 +386,10 @@ export class MemStorage {
       status: msg.status as 'new' | 'replied' | 'auto-replied',
       isHighIntent: msg.isHighIntent || false,
       reply: msg.reply ?? undefined,
-      isAiGenerated: msg.isAiGenerated ?? undefined
+      threadId: msg.threadId ?? undefined,
+      parentMessageId: parentId,
+      isOutbound: msg.isOutbound || false,
+      isAiGenerated: msg.isAiGenerated ?? false
     };
   }
 


### PR DESCRIPTION
## Summary
- include `parentMessageId` when converting messages in MemStorage
- add logger import to content service
- document fix in CHANGELOG

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6844e87986788333b86658ded425ae4f