### PR TITLE
Update reply endpoint in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,8 @@ All notable changes to this project will be documented in this file.
 - [Changed] Instagram credentials now read from environment variables.
 - [Fixed] Implemented thread support in `MemStorage` so replies nest correctly when using in-memory mode.
 
+## 2025-06-08
+- [Changed] Reply endpoint switched to `/api/${source}/reply` and payload now includes `messageId`.
+
 
 

--- a/client/src/components/MessageItem.tsx
+++ b/client/src/components/MessageItem.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-08 [Changed]
 import React, { useState } from 'react';
 import { 
   Card, 
@@ -38,8 +39,8 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
   const { toast } = useToast();
 
   const { mutate: sendReply, isPending: isSending } = useMutation({
-    mutationFn: (data: { reply: string; isAiGenerated: boolean }) => 
-      apiRequest('POST', `/api/messages/${message.id}/reply`, data),
+    mutationFn: (data: { messageId: number; reply: string }) =>
+      apiRequest("POST", `/api/${message.source}/reply`, data),
     onSuccess: () => {
       setIsReplying(false);
       setReplyText("");
@@ -113,7 +114,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
       });
       return;
     }
-    sendReply({ reply: replyText, isAiGenerated: false });
+    sendReply({ messageId: message.id, reply: replyText });
   };
 
   const handleGenerateReply = () => {


### PR DESCRIPTION
## Summary
- change reply endpoint to `/api/${message.source}/reply`
- send `{ messageId, reply }` from the UI
- document change in `CHANGELOG.md`

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68451bf4cdc08333a9529b57a25ac693