### PR TITLE
Fix parent message handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2025-06-08
 - [Changed] Reply endpoint switched to `/api/${source}/reply` and payload now includes `messageId`.
+- [Fixed] Messages with parentMessageId of 0 are now stored as null; client sends null for new parent messages.
 
 
 

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -1,4 +1,5 @@
 // ===== client/src/components/ConversationThread.tsx =====
+// See CHANGELOG.md for 2025-06-08 [Fixed]
 import React, { useRef, useEffect, useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useMessageThreading, ThreadedMessageType } from '@/hooks/useMessageThreading';
@@ -23,7 +24,7 @@ function ThreadedMessage({ msg, threadId }: { msg: ThreadedMessageType; threadId
   const [replyText, setReplyText] = useState('');
   const { toast } = useToast();
   const { mutate: postReply } = useMutation({
-    mutationFn: (payload: { content: string; parentMessageId: number }) =>
+    mutationFn: (payload: { content: string; parentMessageId: number | null }) =>
       apiRequest('POST', `/api/threads/${msg.threadId}/reply`, payload).then(res => res.json()),
   });
   
@@ -127,7 +128,7 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
   const endRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
   const { mutate: postMessage } = useMutation({
-    mutationFn: (payload: { content: string; parentMessageId: number }) =>
+    mutationFn: (payload: { content: string; parentMessageId: number | null }) =>
       apiRequest('POST', `/api/threads/${threadId}/reply`, payload).then(res => res.json()),
   });
   
@@ -179,7 +180,8 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
     if (!replyText.trim() || !threadId) return;
 
     try {
-      postMessage({ content: replyText, parentMessageId: 0 });
+      // parentMessageId of 0 caused server-side issues; see CHANGELOG.md for 2025-06-08 [Fixed]
+      postMessage({ content: replyText, parentMessageId: null });
 
       // Reset form
       setReplyText('');

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,4 @@
-// See CHANGELOG.md for 2025-06-08 [Changed]
+// See CHANGELOG.md for 2025-06-08 [Changed] [Fixed]
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
@@ -392,7 +392,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       if (parentMessageId !== undefined && parentMessageId !== null) {
         parentId = Number(parentMessageId);
-        if (isNaN(parentId)) {
+        // Treat 0 as null to maintain proper root messages
+        if (isNaN(parentId) || parentId === 0) {
           parentId = null;
         }
       }


### PR DESCRIPTION
## Summary
- document fix in changelog
- reference changelog entry in ConversationThread and server routes
- send `null` for new parentMessageId values
- treat parentMessageId `0` as `null` on the server

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845998710148333938a6f66e9ed4786