### PR TITLE
Add pretest dependency check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,9 @@ All notable changes to this project will be documented in this file.
 ## 2025-06-08
 - [Changed] Reply endpoint switched to `/api/${source}/reply` and payload now includes `messageId`.
 
+## 2025-06-08
+- [Added] `npm test` now runs a pretest script that installs dependencies if `vitest` is missing.
+- [Added] README notes that `npm install` must be run so the `vitest` runner is available.
+
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Create a `.env` file with the following variables:
 - `INSTAGRAM_APP_SECRET` – Facebook App Secret for Instagram OAuth
 - `VITE_INSTAGRAM_APP_ID` – Front-end copy of `INSTAGRAM_APP_ID`
 
+## Setup
+
+Run `npm install` before executing tests or starting the server so the
+project's dev dependencies, including the `vitest` test runner, are available.
+Running `npm test` will automatically install dependencies if they are missing.
+
 ## Updating this README
 
 Before making any changes, please:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
+    "pretest": "node scripts/ensure-deps.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "test": "vitest run"

--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -1,0 +1,9 @@
+// See CHANGELOG.md for 2025-06-08 [Added]
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
+
+const vitestPath = 'node_modules/.bin/vitest';
+if (!existsSync(vitestPath)) {
+  console.log('Installing project dependencies...');
+  execSync('npm install', { stdio: 'inherit' });
+}


### PR DESCRIPTION
## Summary
- mention `npm install` in README setup section
- add `pretest` script that ensures `vitest` is installed
- document new behaviour in CHANGELOG
- fix changelog date

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684595d384488333b4552870fc0b2243