### PR TITLE
Update thread row design

### DIFF
--- a/client/src/components/ThreadList.tsx
+++ b/client/src/components/ThreadList.tsx
@@ -2,10 +2,8 @@ import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Badge } from '@/components/ui/badge';
-import { Instagram, Youtube, Search } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import ThreadRow from './ThreadRow';
+import { Search } from 'lucide-react';
 import { ThreadType } from '@shared/schema';
 
 interface ThreadListProps {
@@ -55,26 +53,6 @@ const ThreadList: React.FC<ThreadListProps> = ({
       });
   }, [threads, source, searchTerm]);
   
-  // Function to get source icon
-  const getSourceIcon = (source: string) => {
-    switch (source) {
-      case 'instagram':
-        return <Instagram className="h-4 w-4 mr-1" />;
-      case 'youtube':
-        return <Youtube className="h-4 w-4 mr-1" />;
-      default:
-        return null;
-    }
-  };
-  
-  // Format timestamp
-  const formatTimestamp = (timestamp: string) => {
-    try {
-      return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
-    } catch (error) {
-      return "Unknown time";
-    }
-  };
 
   return (
     <div className="flex flex-col h-full">
@@ -103,44 +81,11 @@ const ThreadList: React.FC<ThreadListProps> = ({
           </div>
         ) : (
           filteredThreads.map((thread: ThreadType) => (
-            <div
+            <ThreadRow
               key={thread.id}
-              className={`border-b border-gray-200 hover:bg-gray-50 cursor-pointer ${
-                activeThreadId === thread.id ? 'bg-gray-100' : ''
-              }`}
+              thread={thread}
               onClick={() => onSelectThread(thread.id, thread)}
-            >
-              <div className="p-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center">
-                    <Avatar className={`h-10 w-10 mr-3 ${thread?.isHighIntent ? 'ring-2 ring-amber-500' : ''}`}>
-                      <AvatarImage 
-                        src={thread?.participantAvatar} 
-                        alt={thread?.participantName || 'User'} 
-                      />
-                      <AvatarFallback>{(thread?.participantName || 'U').charAt(0)}</AvatarFallback>
-                    </Avatar>
-                    <div className="overflow-hidden">
-                      <div className="font-medium text-sm flex items-center">
-                        <span className="truncate">{thread?.participantName || 'User'}</span>
-                        <span className="flex items-center text-xs text-gray-500 ml-2">
-                          {getSourceIcon(thread?.source || '')}
-                        </span>
-                      </div>
-                      <p className="text-xs text-gray-500 truncate">
-                        {formatTimestamp(thread?.lastMessageAt || new Date().toISOString())}
-                      </p>
-                    </div>
-                  </div>
-                  {thread?.unreadCount && thread.unreadCount > 0 && (
-                    <Badge className="bg-blue-500 text-white">{thread.unreadCount}</Badge>
-                  )}
-                </div>
-                <p className="text-sm text-gray-600 mt-1 truncate">
-                  {thread?.lastMessageContent || 'No messages yet'}
-                </p>
-              </div>
-            </div>
+            />
           ))
         )}
       </div>

--- a/client/src/components/ThreadRow.tsx
+++ b/client/src/components/ThreadRow.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { ThreadType, MessageType } from '@shared/schema';
+
+interface ThreadRowProps {
+  thread: ThreadType;
+  onClick?: () => void;
+  creatorId?: string;
+}
+
+const fallbackUrl = 'https://via.placeholder.com/40';
+
+const ThreadRow: React.FC<ThreadRowProps> = ({ thread, onClick, creatorId = 'creator-id' }) => {
+  const lastMsg: MessageType | undefined = thread.messages?.at(-1);
+  const lastMessageAt = lastMsg?.timestamp ?? thread.lastMessageAt;
+  const lastContent = lastMsg?.content ?? thread.lastMessageContent ?? '';
+
+  const senderPrefix = lastMsg
+    ? (lastMsg.sender?.id === creatorId || lastMsg.isOutbound
+        ? 'You:'
+        : thread.participantName.split(' ')[0] + ':')
+    : '';
+
+  const snippet =
+    lastContent.length > 60 ? lastContent.slice(0, 57) + '…' : lastContent;
+
+  return (
+    <div
+      className="flex items-center rounded-lg border border-blue-300 bg-blue-50 px-3 py-2 mb-2"
+      onClick={onClick}
+    >
+      <img
+        src={thread.participantAvatar ?? fallbackUrl}
+        className="w-10 h-10 rounded-full mr-3"
+      />
+      <div className="flex-1">
+        <div className="flex items-center">
+          <span className="font-semibold text-blue-700">{thread.participantName}</span>
+          {thread.isHighIntent && (
+            <span className="ml-2 bg-amber-100 text-amber-800 text-xs font-medium px-2 py-0.5 rounded-md">
+              High Intent
+            </span>
+          )}
+          <span className="ml-auto text-xs text-gray-600">
+            {formatDistanceToNow(new Date(lastMessageAt), { addSuffix: true })}
+          </span>
+          {thread.unreadCount > 0 && (
+            <span className="ml-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
+        </div>
+        <div className="text-gray-700 text-sm truncate">
+          {lastMsg && <span className="font-medium">{senderPrefix}</span>}{' '}
+          {snippet}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ThreadRow;


### PR DESCRIPTION
## Summary
- add new `ThreadRow` component implementing avatar, name, pill, snippet and unread dot
- simplify `ThreadList` to render `ThreadRow`

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845a3173b20833390f5c3b7e4005307