### PR TITLE
Add High Intent avatar ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ## 2025-06-08
 - [Added] `npm test` now runs a pretest script that installs dependencies if `vitest` is missing.
 - [Added] README notes that `npm install` must be run so the `vitest` runner is available.
+- [Codex][Added] Orange avatar ring for high intent conversations in `ThreadRow` and `ConversationThread`.
 
 
 

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -2,6 +2,7 @@
 // See CHANGELOG.md for 2025-06-09 [Fixed]
 // ===== client/src/components/ConversationThread.tsx =====
 // See CHANGELOG.md for 2025-06-08 [Fixed]
+// See CHANGELOG.md for 2025-06-08 [Added]
 import React, { useRef, useEffect, useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useMessageThreading, ThreadedMessageType } from '@/hooks/useMessageThreading';
@@ -245,11 +246,15 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
             </Button>
           )}
           <div className="flex items-center">
-            <div className="w-10 h-10 rounded-full bg-gray-200 mr-3 flex-shrink-0 overflow-hidden">
+            <div
+              className={`w-10 h-10 rounded-full mr-3 flex-shrink-0 overflow-hidden ring-2 ${
+                threadData.isHighIntent ? 'ring-orange-500' : 'ring-gray-300'
+              } bg-gray-200`}
+            >
               {threadData.participantAvatar ? (
-                <img 
-                  src={threadData.participantAvatar} 
-                  alt={threadData.participantName} 
+                <img
+                  src={threadData.participantAvatar}
+                  alt={threadData.participantName}
                   className="w-full h-full object-cover" 
                 />
               ) : (

--- a/client/src/components/ThreadRow.tsx
+++ b/client/src/components/ThreadRow.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-08 [Added]
 import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { ThreadType, MessageType } from '@shared/schema';
@@ -29,10 +30,12 @@ const ThreadRow: React.FC<ThreadRowProps> = ({ thread, onClick, creatorId = 'cre
       className="flex items-center rounded-lg border border-blue-300 bg-blue-50 px-3 py-2 mb-2"
       onClick={onClick}
     >
-      <img
-        src={thread.participantAvatar ?? fallbackUrl}
-        className="w-10 h-10 rounded-full mr-3"
-      />
+        <img
+          src={thread.participantAvatar ?? fallbackUrl}
+          className={`w-10 h-10 rounded-full mr-3 ring-2 ${
+            thread.isHighIntent ? 'ring-orange-500' : 'ring-gray-300'
+          }`}
+        />
       <div className="flex-1">
         <div className="flex items-center">
           <span className="font-semibold text-blue-700">{thread.participantName}</span>


### PR DESCRIPTION
## Summary
- highlight high intent conversations with an orange avatar ring
- keep other conversations using a gray ring
- document change in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846456bf13c8333a7247b8c33e700de