### PR TITLE
Add sample conversation data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,5 @@ All notable changes to this project will be documented in this file.
 ## 2025-06-10
 - [Codex][Added] Gated client logger and removed legacy ConversationThread files.
 
+- [Codex][Added] Sample conversation data for UI testing with high-intent flag.
+- [Codex][Fixed] Converted object logging calls in ConversationThread to strings for TypeScript compatibility.

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -159,15 +159,24 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
     ? useMessageThreading(propMessages).threadedMessages
     : useMessageThreading(fetchedMessages).threadedMessages;
   
- log("Message render triggered", {
-    messagesLoaded: finalMessages ? finalMessages.length : 0,
-    threadId,
-    fetchedCount: fetchedMessages ? fetchedMessages.length : 0
-  });
+  // Stringify metadata for logging to match logger signature
+  log(
+    "Message render triggered " +
+      JSON.stringify({
+        messagesLoaded: finalMessages ? finalMessages.length : 0,
+        threadId,
+        fetchedCount: fetchedMessages ? fetchedMessages.length : 0,
+      })
+  );
   
   if (finalMessages && finalMessages.length > 0) {
     log("Rendering Thread #" + threadId + " with enhanced conversation threading");
-    log("Top-level threaded messages:", finalMessages.map(m => ({ id: m.id, hasChildren: m.childMessages.length })));
+    log(
+      "Top-level threaded messages: " +
+        JSON.stringify(
+          finalMessages.map((m) => ({ id: m.id, hasChildren: m.childMessages.length }))
+        )
+    );
   }
 
   // Scroll to bottom on new messages

--- a/client/src/components/ThreadList.tsx
+++ b/client/src/components/ThreadList.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-10 [Added]
 import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Input } from '@/components/ui/input';
@@ -5,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import ThreadRow from './ThreadRow';
 import { Search } from 'lucide-react';
 import { ThreadType } from '@shared/schema';
+import { sampleConversations } from '@/sampleConversations';
 
 interface ThreadListProps {
   activeThreadId?: number | null;
@@ -24,12 +26,16 @@ const ThreadList: React.FC<ThreadListProps> = ({
     queryKey: ['/api/threads'],
     staleTime: 10000, // 10 seconds
   });
+
+  const threadsData: ThreadType[] | undefined = threads && Array.isArray(threads)
+    ? threads as ThreadType[]
+    : sampleConversations;
   
   // Filter threads by source and search term
   const filteredThreads = React.useMemo(() => {
-    if (!threads) return [];
-    
-    return Array.isArray(threads) ? threads
+    if (!threadsData) return [];
+
+    return Array.isArray(threadsData) ? threadsData
       .filter((thread: ThreadType) => {
         // Filter by source or high intent
         if (source === 'high-intent' && !thread?.isHighIntent) {
@@ -51,7 +57,7 @@ const ThreadList: React.FC<ThreadListProps> = ({
         // Sort by last message date (newest first)
         return new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime();
       });
-  }, [threads, source, searchTerm]);
+  }, [threadsData, source, searchTerm]);
   
 
   return (

--- a/client/src/sampleConversations.ts
+++ b/client/src/sampleConversations.ts
@@ -1,0 +1,41 @@
+// See CHANGELOG.md for 2025-06-10 [Added]
+import { ThreadType } from '@shared/schema';
+
+export const sampleConversations: ThreadType[] = [
+  {
+    id: 1,
+    externalParticipantId: 'user1',
+    participantName: 'Sarah Williams',
+    participantAvatar: 'https://randomuser.me/api/portraits/women/1.jpg',
+    source: 'instagram',
+    lastMessageAt: new Date().toISOString(),
+    lastMessageContent: 'Hello hello',
+    status: 'active',
+    unreadCount: 0,
+    isHighIntent: false,
+  },
+  {
+    id: 2,
+    externalParticipantId: 'test1',
+    participantName: 'Thread 1 - Testing',
+    participantAvatar: 'https://randomuser.me/api/portraits/men/2.jpg',
+    source: 'instagram',
+    lastMessageAt: new Date().toISOString(),
+    lastMessageContent: 'Test high intent',
+    status: 'active',
+    unreadCount: 0,
+    isHighIntent: true,
+  },
+  {
+    id: 3,
+    externalParticipantId: 'user3',
+    participantName: 'Michael Scott',
+    participantAvatar: 'https://randomuser.me/api/portraits/men/3.jpg',
+    source: 'youtube',
+    lastMessageAt: new Date().toISOString(),
+    lastMessageContent: 'Hello',
+    status: 'active',
+    unreadCount: 0,
+    isHighIntent: false,
+  },
+];


### PR DESCRIPTION
## Summary
- create `sampleConversations.ts` with a few high intent users
- use this data in `ThreadList` as a fallback when no API data
- stringify metadata passed to the logger for TypeScript compliance
- document changes in the changelog

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68464582f4d883338f8cdb59a51ab5f1