### PR TITLE
Add message and thread deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,6 @@ All notable changes to this project will be documented in this file.
 
 - [Codex][Added] Sample conversation data for UI testing with high-intent flag.
 - [Codex][Fixed] Converted object logging calls in ConversationThread to strings for TypeScript compatibility.
+
+## 2025-06-11
+- [Codex][Added] Message and thread deletion with WhatsApp-style actions.

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-11 [Added]
 // See CHANGELOG.md for 2025-06-10 [Added]
 // See CHANGELOG.md for 2025-06-10 [Fixed]
 // See CHANGELOG.md for 2025-06-09 [Fixed]
@@ -5,15 +6,17 @@
 // See CHANGELOG.md for 2025-06-08 [Fixed]
 // See CHANGELOG.md for 2025-06-08 [Added]
 import React, { useRef, useEffect, useState } from 'react';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMessageThreading, ThreadedMessageType } from '@/hooks/useMessageThreading';
 import { MessageType } from '@shared/schema';
-import { Loader2, Send } from 'lucide-react';
+import { Loader2, Send, MoreVertical } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import { log } from '@/lib/logger';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 interface ConversationThreadProps {
   threadId?: number;
@@ -21,13 +24,27 @@ interface ConversationThreadProps {
   messages?: MessageType[];
   showBackButton?: boolean;
   onBack?: () => void;
+  onDeleted?: () => void;
 }
 
 // Recursive renderer for threaded messages
-function ThreadedMessage({ msg, threadId }: { msg: ThreadedMessageType; threadId: number }) {
+function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: ThreadedMessageType; threadId: number; setShowMobileActions: React.Dispatch<React.SetStateAction<{ id: number; onReply: () => void; onDelete: () => void } | null>> }) {
   const [isReplying, setIsReplying] = useState(false);
   const [replyText, setReplyText] = useState('');
   const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
+  const holdTimer = useRef<NodeJS.Timeout | null>(null);
+  const { mutate: deleteMessage } = useMutation({
+    mutationFn: (id: number) => apiRequest('DELETE', `/api/messages/${id}`, {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['thread-messages', threadId] });
+      toast({ title: 'Message deleted' });
+    },
+    onError: () => {
+      toast({ title: 'Failed to delete message', variant: 'destructive' });
+    }
+  });
   const { mutate: postReply } = useMutation({
     mutationFn: (payload: { content: string; parentMessageId: number | null }) =>
       apiRequest('POST', `/api/threads/${msg.threadId}/reply`, payload).then(res => res.json()),
@@ -46,6 +63,22 @@ function ThreadedMessage({ msg, threadId }: { msg: ThreadedMessageType; threadId
     // Reset form
     setReplyText('');
     setIsReplying(false);
+  };
+
+  const handleDelete = () => deleteMessage(msg.id);
+
+  const startHold = () => {
+    if (!isMobile) return;
+    holdTimer.current = setTimeout(() => {
+      setShowMobileActions({ id: msg.id, onReply: () => setIsReplying(true), onDelete: handleDelete });
+    }, 500);
+  };
+
+  const cancelHold = () => {
+    if (holdTimer.current) {
+      clearTimeout(holdTimer.current);
+      holdTimer.current = null;
+    }
   };
   
   return (
@@ -68,16 +101,21 @@ function ThreadedMessage({ msg, threadId }: { msg: ThreadedMessageType; threadId
           <div className="flex-1">
             <div className="text-sm font-semibold">{msg.sender?.name || 'User'}</div>
             <div className="text-sm text-gray-800 whitespace-pre-wrap">{msg.content}</div>
-            <div className="flex justify-between items-center mt-1">
+            <div className="flex justify-between items-center mt-1" onTouchStart={startHold} onTouchEnd={cancelHold}>
               <div className="text-xs text-gray-500">{new Date(msg.timestamp).toLocaleString()}</div>
-              <Button 
-                variant="ghost" 
-                size="sm" 
-                className="text-xs text-gray-500 h-6 px-2"
-                onClick={() => setIsReplying(!isReplying)}
-              >
-                Reply
-              </Button>
+              {!isMobile && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" className="h-6 w-6">
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuItem onSelect={() => setIsReplying(true)}>Reply</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={handleDelete}>Delete</DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
             
             {/* Reply form */}
@@ -114,7 +152,7 @@ function ThreadedMessage({ msg, threadId }: { msg: ThreadedMessageType; threadId
       {msg.childMessages.length > 0 && (
         <div className="mt-2">
           {msg.childMessages.map(child => (
-            <ThreadedMessage key={child.id} msg={child} threadId={threadId} />
+            <ThreadedMessage key={child.id} msg={child} threadId={threadId} setShowMobileActions={setShowMobileActions} />
           ))}
         </div>
       )}
@@ -127,14 +165,30 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
   threadData,
   messages: propMessages,
   showBackButton = false,
-  onBack
+  onBack,
+  onDeleted
 }) => {
   const [replyText, setReplyText] = useState('');
   const endRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
+  const [showMobileActions, setShowMobileActions] = useState<{ id: number; onReply: () => void; onDelete: () => void } | null>(null);
   const { mutate: postMessage } = useMutation({
     mutationFn: (payload: { content: string; parentMessageId: number | null }) =>
       apiRequest('POST', `/api/threads/${threadId}/reply`, payload).then(res => res.json()),
+  });
+
+  const { mutate: deleteThread } = useMutation({
+    mutationFn: () => apiRequest('DELETE', `/api/threads/${threadId}`, {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/threads'] });
+      toast({ title: 'Thread deleted' });
+      onDeleted?.();
+    },
+    onError: () => {
+      toast({ title: 'Failed to delete thread', variant: 'destructive' });
+    }
   });
   
   // Fetch flat messages for the thread and build the threaded hierarchy on the client
@@ -286,6 +340,29 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
               </div>
             </div>
           </div>
+          <div className="ml-auto">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon">
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={() => deleteThread()}>Delete Thread</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      )}
+
+      {isMobile && showMobileActions && (
+        <div className="fixed top-0 left-0 right-0 bg-white border-b z-20 flex justify-end space-x-2 p-2">
+          <Button size="sm" variant="ghost" onClick={() => { showMobileActions.onReply(); setShowMobileActions(null); }}>
+            Reply
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => { showMobileActions.onDelete(); setShowMobileActions(null); }}>
+            Delete
+          </Button>
         </div>
       )}
       
@@ -298,7 +375,7 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
         ) : (
           <>
             {finalMessages.map(root => (
-              <ThreadedMessage key={root.id} msg={root} threadId={threadId!} />
+              <ThreadedMessage key={root.id} msg={root} threadId={threadId!} setShowMobileActions={setShowMobileActions} />
             ))}
           </>
         )}

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-11 [Added]
 import React, { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import ThreadList from '@/components/ThreadList';
@@ -148,10 +149,11 @@ const ThreadedMessages: React.FC = () => {
               </div>
               <div className="flex-1 overflow-auto">
                 {activeThreadId && (
-                  <ConversationThread 
+                  <ConversationThread
                     threadId={activeThreadId}
                     threadData={activeThreadData}
                     showBackButton={false}
+                    onDeleted={() => setActiveThreadId(null)}
                   />
                 )}
               </div>
@@ -176,11 +178,12 @@ const ThreadedMessages: React.FC = () => {
           
           {/* Conversation thread */}
           <div className="md:w-2/3 lg:w-3/4 h-full">
-            <ConversationThread 
-              threadId={activeThreadId}
-              threadData={activeThreadData}
-              showBackButton={false}
-            />
+          <ConversationThread
+            threadId={activeThreadId}
+            threadData={activeThreadData}
+            showBackButton={false}
+            onDeleted={() => setActiveThreadId(null)}
+          />
           </div>
         </div>
       );
@@ -200,7 +203,7 @@ const ThreadedMessages: React.FC = () => {
         {/* Conversation thread */}
         <div className="hidden md:block md:w-2/3 lg:w-3/4 h-full">
           {activeThreadId ? (
-            <ConversationThread threadId={activeThreadId} />
+            <ConversationThread threadId={activeThreadId} onDeleted={() => setActiveThreadId(null)} />
           ) : (
             <div className="flex items-center justify-center h-full text-center p-4">
               <div>

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-11 [Added]
 import { 
   messages, 
   users, 
@@ -225,12 +226,25 @@ export class DatabaseStorage implements IStorage {
           unreadCount: 0,
         })
         .where(eq(messageThreads.id, threadId));
-      
+
       return true;
     } catch (error) {
       console.error("Error marking thread as read:", error);
       return false;
     }
+  }
+
+  async deleteMessage(id: number): Promise<boolean> {
+    await db.delete(messages).where(eq(messages.id, id));
+    const [message] = await db.select().from(messages).where(eq(messages.id, id));
+    return message === undefined;
+  }
+
+  async deleteThread(id: number): Promise<boolean> {
+    await db.delete(messages).where(eq(messages.threadId, id));
+    await db.delete(messageThreads).where(eq(messageThreads.id, id));
+    const [thread] = await db.select().from(messageThreads).where(eq(messageThreads.id, id));
+    return thread === undefined;
   }
 
   // Content methods for RAG pipeline

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-11 [Added]
 
 // See CHANGELOG.md for 2025-06-08 [Fixed]
 import type { Express } from "express";
@@ -471,6 +472,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.delete('/api/threads/:id', async (req, res) => {
+    try {
+      const threadId = parseInt(req.params.id);
+      const success = await storage.deleteThread(threadId);
+      if (!success) {
+        return res.status(404).json({ message: 'Thread not found' });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error deleting thread:', error);
+      res.status(500).json({ message: 'Failed to delete thread' });
+    }
+  });
+
   // API endpoints to get messages from different platforms
   app.get('/api/messages/instagram', async (req, res) => {
     try {
@@ -491,6 +506,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error('Error fetching YouTube messages:', error);
       res.status(500).json({ error: String(error) });
+    }
+  });
+
+  app.delete('/api/messages/:id', async (req, res) => {
+    try {
+      const messageId = parseInt(req.params.id);
+      const success = await storage.deleteMessage(messageId);
+      if (!success) {
+        return res.status(404).json({ message: 'Message not found' });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error deleting message:', error);
+      res.status(500).json({ message: 'Failed to delete message' });
     }
   });
   

--- a/server/storage-delete.test.ts
+++ b/server/storage-delete.test.ts
@@ -1,0 +1,29 @@
+// See CHANGELOG.md for 2025-06-11 [Added]
+import { describe, it, expect } from 'vitest'
+import { MemStorage } from './storage'
+
+describe('MemStorage delete methods', () => {
+  it('deletes a message and thread', async () => {
+    const storage = new MemStorage()
+    const thread = await storage.createThread({
+      userId: 1,
+      externalParticipantId: 'x',
+      participantName: 'user',
+      source: 'instagram',
+      metadata: {}
+    })
+    await storage.addMessageToThread(thread.id, {
+      content: 'hi',
+      source: 'instagram',
+      externalId: 'e1',
+      senderId: 's',
+      senderName: 's',
+      userId: 1,
+      metadata: {}
+    })
+    const deletedMsg = await storage.deleteMessage(1)
+    expect(deletedMsg).toBe(true)
+    const deletedThread = await storage.deleteThread(thread.id)
+    expect(deletedThread).toBe(true)
+  })
+})

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-11 [Added]
 // [Fixed] 2025-06-09 - add in-memory thread support for conversation threads
 import {
   messages, 
@@ -565,6 +566,23 @@ export class MemStorage {
     const thread = this.threads.get(threadId);
     if (!thread) return false;
     this.threads.set(threadId, { ...thread, unreadCount: 0 });
+    return true;
+  }
+
+  async deleteMessage(id: number): Promise<boolean> {
+    if (!this.msgs.has(id)) return false;
+    this.msgs.delete(id);
+    return true;
+  }
+
+  async deleteThread(id: number): Promise<boolean> {
+    if (!this.threads.has(id)) return false;
+    this.threads.delete(id);
+    for (const [mid, msg] of Array.from(this.msgs.entries())) {
+      if (msg.threadId === id) {
+        this.msgs.delete(mid);
+      }
+    }
     return true;
   }
 


### PR DESCRIPTION
## Summary
- enable deleting individual messages and entire threads
- hook new actions into mobile hold menu and desktop dropdown
- add backend delete routes with storage logic
- pass thread deletion info back to the thread list
- test storage deletion methods

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68465987ff4883338b04fcc40f9a3631