### PR TITLE
Fix high-intent thread flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ All notable changes to this project will be documented in this file.
 
 - [Codex][Added] Sample conversation data for UI testing with high-intent flag.
 - [Codex][Fixed] Converted object logging calls in ConversationThread to strings for TypeScript compatibility.
+- [Codex][Fixed] High-intent threads are now flagged correctly.

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -1,6 +1,7 @@
-import { 
-  messages, 
-  users, 
+// [Fixed] 2025-06-10 - high-intent threads are now flagged correctly
+import {
+  messages,
+  users,
   settings, 
   automationRules, 
   leads, 
@@ -25,7 +26,7 @@ import {
   type ThreadType
 } from "@shared/schema";
 import { db } from "./db";
-import { eq, desc, and } from "drizzle-orm";
+import { eq, desc, and, inArray, sql } from "drizzle-orm";
 import { IStorage } from "./storage";
 import { log } from "./logger";
 
@@ -53,7 +54,22 @@ export class DatabaseStorage implements IStorage {
 
     // Order by most recent message
     const threads = await query.orderBy(desc(messageThreads.lastMessageAt));
-    
+
+    if (threads.length === 0) return [];
+
+    const intentRows = await db
+      .select({
+        threadId: messages.threadId,
+        highIntent: sql<boolean>`bool_or(${messages.isHighIntent})`
+      })
+      .from(messages)
+      .where(inArray(messages.threadId, threads.map(t => t.id)))
+      .groupBy(messages.threadId);
+
+    const intentMap = new Map<number, boolean>(
+      intentRows.map(r => [r.threadId!, Boolean(r.highIntent)])
+    );
+
     // Map to ThreadType
     return threads.map(thread => ({
       id: thread.id,
@@ -64,7 +80,8 @@ export class DatabaseStorage implements IStorage {
       lastMessageAt: thread.lastMessageAt.toISOString(),
       lastMessageContent: thread.lastMessageContent || undefined,
       status: thread.status as 'active' | 'archived' | 'snoozed',
-      unreadCount: thread.unreadCount || 0
+      unreadCount: thread.unreadCount || 0,
+      isHighIntent: intentMap.get(thread.id) ?? false
     }));
   }
   

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,5 @@
 // [Fixed] 2025-06-09 - add in-memory thread support for conversation threads
+// [Fixed] 2025-06-10 - high-intent threads are now flagged correctly
 import {
   messages, 
   users, 
@@ -477,17 +478,23 @@ export class MemStorage {
       t => t.userId === userId && (!source || t.source === source)
     ).sort((a, b) => b.lastMessageAt.getTime() - a.lastMessageAt.getTime());
 
-    return threads.map(t => ({
-      id: t.id,
-      externalParticipantId: t.externalParticipantId,
-      participantName: t.participantName,
-      participantAvatar: t.participantAvatar || undefined,
-      source: t.source as 'instagram' | 'youtube',
-      lastMessageAt: t.lastMessageAt.toISOString(),
-      lastMessageContent: t.lastMessageContent || undefined,
-      status: t.status as 'active' | 'archived' | 'snoozed',
-      unreadCount: t.unreadCount || 0
-    }));
+    return threads.map(t => {
+      const highIntent = Array.from(this.msgs.values()).some(
+        m => m.threadId === t.id && m.isHighIntent
+      );
+      return {
+        id: t.id,
+        externalParticipantId: t.externalParticipantId,
+        participantName: t.participantName,
+        participantAvatar: t.participantAvatar || undefined,
+        source: t.source as 'instagram' | 'youtube',
+        lastMessageAt: t.lastMessageAt.toISOString(),
+        lastMessageContent: t.lastMessageContent || undefined,
+        status: t.status as 'active' | 'archived' | 'snoozed',
+        unreadCount: t.unreadCount || 0,
+        isHighIntent: highIntent
+      };
+    });
   }
 
   async getThreadMessages(threadId: number): Promise<MessageType[]> {


### PR DESCRIPTION
## Summary
- add high-intent flag to thread return types
- compute high-intent on in-memory threads
- aggregate `isHighIntent` in database storage
- document fix in CHANGELOG

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68465bd17f4883338f0a911171d395f4