### PR TITLE
Fix fallback thread list logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ All notable changes to this project will be documented in this file.
 
 - [Codex][Added] Sample conversation data for UI testing with high-intent flag.
 - [Codex][Fixed] Converted object logging calls in ConversationThread to strings for TypeScript compatibility.
+- [Codex][Fixed] UI now displays sample threads when no data is returned.

--- a/client/src/components/ThreadList.tsx
+++ b/client/src/components/ThreadList.tsx
@@ -1,4 +1,5 @@
 // See CHANGELOG.md for 2025-06-10 [Added]
+// See CHANGELOG.md for 2025-06-10 [Fixed]
 import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Input } from '@/components/ui/input';
@@ -27,9 +28,11 @@ const ThreadList: React.FC<ThreadListProps> = ({
     staleTime: 10000, // 10 seconds
   });
 
-  const threadsData: ThreadType[] | undefined = threads && Array.isArray(threads)
-    ? threads as ThreadType[]
-    : sampleConversations;
+  // Use sample conversations when the API returns an empty list
+  const threadsData: ThreadType[] | undefined =
+    threads && Array.isArray(threads) && threads.length > 0
+      ? (threads as ThreadType[])
+      : sampleConversations;
   
   // Filter threads by source and search term
   const filteredThreads = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- default to sample conversations when API returns an empty list
- document the change in the changelog

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68465bd3c18c83339471f480e68b5f03