### PR TITLE
Fix last message display in thread list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,6 @@ All notable changes to this project will be documented in this file.
 - [Codex][Fixed] Deletion actions now immediately update the UI cache.
 
 
+
+## 2025-06-12
+- [Codex][Fixed] Conversation list now shows the latest message with the sender's first name.

--- a/client/src/components/ThreadRow.tsx
+++ b/client/src/components/ThreadRow.tsx
@@ -1,6 +1,7 @@
 
 // See CHANGELOG.md for 2025-06-08 [Added]
 // See CHANGELOG.md for 2025-06-10 [Changed]
+// See CHANGELOG.md for 2025-06-12 [Fixed]
 
 import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
@@ -15,14 +16,22 @@ interface ThreadRowProps {
 const fallbackUrl = 'https://via.placeholder.com/40';
 
 const ThreadRow: React.FC<ThreadRowProps> = ({ thread, onClick, creatorId = 'creator-id' }) => {
-  const lastMsg: MessageType | undefined = thread.messages?.at(-1);
+  const lastMsg: MessageType | undefined = React.useMemo(() => {
+    if (!Array.isArray(thread.messages) || thread.messages.length === 0) {
+      return undefined;
+    }
+    return thread.messages.reduce((latest, msg) => {
+      return new Date(msg.timestamp).getTime() > new Date(latest.timestamp).getTime() ? msg : latest;
+    });
+  }, [thread.messages]);
+
   const lastMessageAt = lastMsg?.timestamp ?? thread.lastMessageAt;
   const lastContent = lastMsg?.content ?? thread.lastMessageContent ?? '';
 
   const senderPrefix = lastMsg
     ? (lastMsg.sender?.id === creatorId || lastMsg.isOutbound
         ? 'You:'
-        : thread.participantName.split(' ')[0] + ':')
+        : (lastMsg.sender?.name.split(' ')[0] || thread.participantName.split(' ')[0]) + ':')
     : '';
 
   const snippet =


### PR DESCRIPTION
## Summary
- show latest message sender's name in thread list
- update changelog

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6847006bcfb48333a81aca3ee283a27b