### PR TITLE
Fix thread snippet overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,7 @@ All notable changes to this project will be documented in this file.
 - [Codex][Added] Message and thread deletion with WhatsApp-style actions.
 - [Codex][Fixed] Deletion actions now immediately update the UI cache.
 
+## 2025-06-10
+- [Codex][Fixed] Thread list messages now truncate within the container and show the full text on hover or long press.
+
 

--- a/client/src/components/ThreadRow.tsx
+++ b/client/src/components/ThreadRow.tsx
@@ -1,6 +1,7 @@
 
 // See CHANGELOG.md for 2025-06-08 [Added]
 // See CHANGELOG.md for 2025-06-10 [Changed]
+// See CHANGELOG.md for 2025-06-10 [Fixed]
 
 import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
@@ -25,8 +26,6 @@ const ThreadRow: React.FC<ThreadRowProps> = ({ thread, onClick, creatorId = 'cre
         : thread.participantName.split(' ')[0] + ':')
     : '';
 
-  const snippet =
-    lastContent.length > 60 ? lastContent.slice(0, 57) + '…' : lastContent;
 
   return (
     <div
@@ -54,9 +53,12 @@ const ThreadRow: React.FC<ThreadRowProps> = ({ thread, onClick, creatorId = 'cre
             <span className="ml-1 w-2 h-2 bg-red-500 rounded-full" />
           )}
         </div>
-        <div className="text-gray-700 text-sm truncate">
+        <div
+          className="text-gray-700 text-sm truncate w-full"
+          title={`${lastMsg ? senderPrefix + ' ' : ''}${lastContent}`}
+        >
           {lastMsg && <span className="font-medium">{senderPrefix}</span>}{' '}
-          {snippet}
+          {lastContent}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- truncate thread snippet text within the container
- show the full message on hover/long press via the title attribute
- document changes in CHANGELOG

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684700b062fc8333adc977de6b6aefb3