### PR TITLE
Fix left pane chip truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@ All notable changes to this project will be documented in this file.
 - [Codex][Fixed] Conversation list now shows the latest message with the sender's first name.
 - [Codex][Fixed] Restored conversation chip rendering in `ThreadRow` and added unit test.
 - [Codex][Fixed] Thread list now refreshes immediately after sending a reply so the left pane chip updates.
+- [Codex][Fixed-3] Added `min-w-0` to `ThreadRow` container so conversation chips truncate correctly.

--- a/client/src/components/ThreadRow.test.tsx
+++ b/client/src/components/ThreadRow.test.tsx
@@ -1,4 +1,5 @@
 // See CHANGELOG.md for 2025-06-09 [Fixed]
+// See CHANGELOG.md for 2025-06-09 [Fixed-3]
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -38,5 +39,12 @@ describe('ThreadRow', () => {
     expect(html).toContain('John Doe');
     expect(html).toContain('Hello there');
     expect(html).toContain('bg-gray-300');
+  });
+
+  it('includes min-w-0 class for snippet truncation', () => {
+    const html = renderToStaticMarkup(
+      <ThreadRow thread={sampleThread} selected={false} />
+    );
+    expect(html).toContain('min-w-0');
   });
 });

--- a/client/src/components/ThreadRow.tsx
+++ b/client/src/components/ThreadRow.tsx
@@ -4,6 +4,7 @@
 // See CHANGELOG.md for 2025-06-11 [Fixed]
 // See CHANGELOG.md for 2025-06-11 [Fixed-2]
 // See CHANGELOG.md for 2025-06-09 [Fixed]
+// See CHANGELOG.md for 2025-06-09 [Fixed-3]
 
 import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
@@ -46,7 +47,8 @@ const ThreadRow: React.FC<ThreadRowProps> = ({ thread, onClick, creatorId = 'cre
             thread.isHighIntent ? 'ring-orange-500' : 'ring-gray-300'
           }`}
         />
-      <div className="flex-1">
+      {/* Ensure flex item can shrink so the snippet truncates correctly */}
+      <div className="flex-1 min-w-0">
         <div className="flex items-center">
           <span className="font-semibold text-gray-900">{thread.participantName}</span>
           {thread.isHighIntent && (


### PR DESCRIPTION
## Summary
- fix conversation snippet not truncating by letting flex item shrink
- test thread row has `min-w-0` class
- document change in changelog

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68473cd8d658833387766346f8cb44e0