### PR TITLE
Fix missing testing tools menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,4 @@ All notable changes to this project will be documented in this file.
 - [Codex][Fixed] Restored conversation chip rendering in `ThreadRow` and added unit test.
 - [Codex][Fixed] Thread list now refreshes immediately after sending a reply so the left pane chip updates.
 - [Codex][Fixed-3] Added `min-w-0` to `ThreadRow` container so conversation chips truncate correctly.
+- [Codex][Added] Sidebar now includes a link to the Testing Tools page.

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-09 [Added]
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
 import { 
@@ -88,6 +89,14 @@ const Sidebar = ({ className }: SidebarProps) => {
                 active={location === "/automation"}
               >
                 Automation Rules
+              </NavItem>
+              {/* Testing tools page for generating sample data and debugging */}
+              <NavItem
+                href="/testing"
+                icon={<Code />}
+                active={location === "/testing"}
+              >
+                Testing Tools
               </NavItem>
 
 


### PR DESCRIPTION
## Summary
- expose Testing Tools via new sidebar link

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68479812de9c8333ab24c9bef87ea53a