### PR TITLE
Fix tools dropdown alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,5 +44,7 @@ All notable changes to this project will be documented in this file.
 - [Replit Assistant][Changed] README now directs users to the Testing Tools page instead of the Messages page Tools accordion.
 - [Codex][Changed] Tools menu restored to the main Messages interface for easier access.
 
+- [Codex][Changed] Tools dropdown aligned with trigger using `right-0` so menu stays on screen.
+
 ## 2025-06-10
 - [Codex][Added] Tools accordion on Messages page now includes refresh and webhook options.

--- a/client/src/pages/messages/Messages.tsx
+++ b/client/src/pages/messages/Messages.tsx
@@ -1,5 +1,6 @@
 // See CHANGELOG.md for 2025-06-09 [Added]
 // See CHANGELOG.md for 2025-06-10 [Added]
+// See CHANGELOG.md for 2025-06-09 [Changed]
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import MessageItem from "@/components/MessageItem";
@@ -124,7 +125,7 @@ const Messages = () => {
                     <FileQuestion className="h-4 w-4 mr-2" />
                     Tools
                   </AccordionTrigger>
-                  <AccordionContent className="absolute z-10 mt-1 bg-white border border-gray-200 shadow-lg rounded w-64">
+                  <AccordionContent className="absolute right-0 z-10 mt-1 bg-white border border-gray-200 shadow-lg rounded w-64">
                     <div className="px-4 py-3">
                       <Button
                         className="w-full mb-2 bg-gray-900 text-white hover:bg-gray-800 border-gray-900"

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -1,6 +1,7 @@
 // See CHANGELOG.md for 2025-06-11 [Added]
 // See CHANGELOG.md for 2025-06-12 [Fixed]
 // See CHANGELOG.md for 2025-06-09 [Changed]
+// See CHANGELOG.md for 2025-06-09 [Changed - dropdown alignment]
 import React, { useState, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import ThreadList from '@/components/ThreadList';
@@ -259,7 +260,7 @@ const ThreadedMessages: React.FC = () => {
                     <FileQuestion className="h-4 w-4 mr-2" />
                     Tools
                   </AccordionTrigger>
-                  <AccordionContent className="absolute z-10 mt-1 bg-white border border-gray-200 shadow-lg rounded w-64">
+                  <AccordionContent className="absolute right-0 z-10 mt-1 bg-white border border-gray-200 shadow-lg rounded w-64">
                     <div className="px-4 py-3">
                       <Button
                         className="w-full mb-2 bg-gray-900 text-white hover:bg-gray-800 border-gray-900"


### PR DESCRIPTION
## Summary
- align Tools dropdown to button using `right-0`
- note change in changelog

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6847a9a01d3c8333a31bf27b73abfaaf