### PR TITLE
Use thread info in generate-for-user route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,5 +48,7 @@ All notable changes to this project will be documented in this file.
 
 - [Codex][Changed] "Generate For Thread" now uses a dropdown populated with thread names.
 
+- [Codex][Changed] `/api/test/generate-for-user` now uses thread participant details and generates content referencing the participant.
+
 ## 2025-06-10
 - [Codex][Added] Tools accordion on Messages page now includes refresh and webhook options.

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -55,6 +55,8 @@ describe('test routes', () => {
     expect(res.status).toBe(200)
     const msg = await res.json()
     expect(msg.threadId).toBe(thread.id)
+    expect(msg.senderName).toBe(thread.participantName)
+    expect(msg.content.length).toBeGreaterThan(0)
     const msgs = await mem.getThreadMessages(thread.id)
     expect(msgs.some(m => m.id === msg.id)).toBe(true)
   })

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,6 @@
 // See CHANGELOG.md for 2025-06-11 [Added]
 // See CHANGELOG.md for 2025-06-09 [Added]
+// See CHANGELOG.md for 2025-06-09 [Changed]
 
 // See CHANGELOG.md for 2025-06-08 [Fixed]
 import type { Express } from "express";
@@ -305,13 +306,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: 'Thread not found' });
       }
 
+      const content = `Hi ${thread.participantName}, this is a test message.`;
+
       const msg = await storage.addMessageToThread(threadId, {
         source: thread.source || 'instagram',
-        content: faker.lorem.sentence(),
+        content,
         externalId: `faker-${Date.now()}`,
-        senderId: faker.internet.userName().toLowerCase(),
-        senderName: faker.person.fullName(),
-        senderAvatar: faker.image.avatar(),
+        senderId: thread.externalParticipantId,
+        senderName: thread.participantName,
+        senderAvatar: thread.participantAvatar || faker.image.avatar(),
         timestamp: new Date(),
         status: 'new',
         isHighIntent: false,


### PR DESCRIPTION
## Summary
- tailor `/api/test/generate-for-user` to use thread participant details
- validate sender name and content in the route tests
- document the endpoint change in the changelog

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847ae64d024833385bdd17e2f809b61