### PR TITLE
Align outgoing messages right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,4 +54,5 @@ All notable changes to this project will be documented in this file.
 - [Codex] [dded]"Generate Reply" button in `ConversationThread` for AI-assisted replies.
 - [Codex] [Added] Settings page now includes a Flex processing toggle and backend honors the field in OpenAI requests.
 - [Codex] [Changed] Desktop view now wraps long message text instead of truncating it.
+- [Codex] [Changed] Conversation thread now aligns outbound messages to the right and removes avatars for a WhatsApp-style view.
 

--- a/client/src/components/ConversationThread.test.tsx
+++ b/client/src/components/ConversationThread.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ConversationThread from './ConversationThread';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MessageType } from '@shared/schema';
+
+const messages: MessageType[] = [
+  {
+    id: 1,
+    threadId: 1,
+    source: 'instagram',
+    content: 'Hi there',
+    sender: { id: 'u1', name: 'Alice' },
+    timestamp: new Date('2025-06-01T00:00:00Z').toISOString(),
+    status: 'new',
+    isHighIntent: false,
+    isOutbound: false,
+  },
+  {
+    id: 2,
+    threadId: 1,
+    source: 'instagram',
+    content: 'Reply from me',
+    sender: { id: 'u2', name: 'Me' },
+    timestamp: new Date('2025-06-01T00:01:00Z').toISOString(),
+    status: 'new',
+    isHighIntent: false,
+    isOutbound: true,
+  }
+];
+
+describe('ConversationThread layout', () => {
+  it('renders outbound messages with flex-row-reverse and no avatars', () => {
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <ConversationThread threadId={1} messages={messages} />
+      </QueryClientProvider>
+    );
+    const count = (html.match(/flex-row-reverse/g) || []).length;
+    expect(count).toBe(1);
+    expect(html.includes('<img')).toBe(false);
+  });
+});

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -1,4 +1,5 @@
 // See CHANGELOG.md for 2025-06-11 [Added]
+// See CHANGELOG.md for 2025-06-10 [Changed-2]
 // See CHANGELOG.md for 2025-06-10 [Added]
 // See CHANGELOG.md for 2025-06-10 [Added-2]
 // See CHANGELOG.md for 2025-06-10 [Fixed]
@@ -152,8 +153,6 @@ function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: Threade
     }
   });
   
-  // Display default avatar if none provided
-  const avatarUrl = msg.sender?.avatar || 'https://ui-avatars.com/api/?name=' + encodeURIComponent(msg.sender?.name || 'User');
   
   // Handle reply submission
   const handleReplySubmit = async (e: React.FormEvent) => {
@@ -198,20 +197,16 @@ function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: Threade
         />
       )}
       
-      <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-3">
-        <div className="flex items-start">
-          <img
-            src={avatarUrl}
-            alt={msg.sender?.name || 'User'}
-            className="w-8 h-8 rounded-full mr-2"
-          />
-          <div className="flex-1">
-            <div className="text-sm font-semibold">{msg.sender?.name || 'User'}</div>
-            {/* Message content with truncation and hover/long-press support */}
-            <MessageContent content={msg.content} showFullContent={showFullContent} setShowFullContent={setShowFullContent} isMobile={isMobile} />
-            <div className="flex justify-between items-center mt-1" onTouchStart={startHold} onTouchEnd={cancelHold}>
-              <div className="text-xs text-gray-500">{new Date(msg.timestamp).toLocaleString()}</div>
-              {!isMobile && (
+      <div className={`flex ${msg.isOutbound ? 'justify-end' : ''}`}> 
+        <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-3 max-w-[75%]">
+          <div className={`flex items-start ${msg.isOutbound ? 'flex-row-reverse text-right' : ''}`}>
+            <div className="flex-1">
+              <div className="text-sm font-semibold">{msg.sender?.name || 'User'}</div>
+              {/* Message content with truncation and hover/long-press support */}
+              <MessageContent content={msg.content} showFullContent={showFullContent} setShowFullContent={setShowFullContent} isMobile={isMobile} />
+              <div className="flex justify-between items-center mt-1" onTouchStart={startHold} onTouchEnd={cancelHold}>
+                <div className="text-xs text-gray-500">{new Date(msg.timestamp).toLocaleString()}</div>
+                {!isMobile && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" size="icon" className="h-6 w-6">
@@ -268,7 +263,8 @@ function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: Threade
           </div>
         </div>
       </div>
-      
+    </div>
+
       {/* Render child messages */}
       {msg.childMessages.length > 0 && (
         <div className="mt-2">

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['**/*.test.ts'],
+    include: ['**/*.test.ts', '**/*.test.tsx'],
     env: {
       DATABASE_URL: 'postgres://test'
     }


### PR DESCRIPTION
## Summary
- improve conversation thread styling for WhatsApp look
- add vitest config support for `.test.tsx` files
- test outbound message alignment

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6848740a59d08333a4ebf555a32a390f