### PR TITLE
Add AI reply button at composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,4 +55,5 @@ All notable changes to this project will be documented in this file.
 - [Codex] [Added] Settings page now includes a Flex processing toggle and backend honors the field in OpenAI requests.
 - [Codex] [Changed] Desktop view now wraps long message text instead of truncating it.
 - [Codex] [Changed] Conversation thread now aligns outbound messages to the right and removes avatars for a WhatsApp-style view.
+- [Codex] [Added] Composer "Generate Reply" button populates the message input.
 

--- a/client/src/components/ConversationThread.test.tsx
+++ b/client/src/components/ConversationThread.test.tsx
@@ -41,4 +41,13 @@ describe('ConversationThread layout', () => {
     expect(count).toBe(1);
     expect(html.includes('<img')).toBe(false);
   });
+
+  it('renders Generate Reply button in the composer', () => {
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <ConversationThread threadId={1} messages={messages} />
+      </QueryClientProvider>
+    );
+    expect(html.includes('data-testid="composer-generate"')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- allow generating AI replies at the bottom of ConversationThread
- populate the message input with generated text
- test that the new button renders

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68487848cb28833391a9b459f3144735