### PR TITLE
Remove redundant thread lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,5 @@ All notable changes to this project will be documented in this file.
 - [Codex] [Changed] Conversation thread now aligns outbound messages to the right and removes avatars for a WhatsApp-style view.
 - [Codex] [Added] Composer "Generate Reply" button populates the message input.
 
+- [Codex][Removed] Vertical thread lines from conversation and reply UI.
+

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -1,4 +1,5 @@
 // See CHANGELOG.md for 2025-06-11 [Added]
+// See CHANGELOG.md for 2025-06-10 [Removed]
 // See CHANGELOG.md for 2025-06-10 [Changed-2]
 // See CHANGELOG.md for 2025-06-10 [Added]
 // See CHANGELOG.md for 2025-06-10 [Added-2]
@@ -189,14 +190,7 @@ function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: Threade
   };
   
   return (
-    <div style={{ paddingLeft: msg.depth * 20 }} className="mb-4 relative">
-      {/* Vertical line connecting replies */}
-      {msg.depth > 0 && (
-        <div 
-          className="absolute left-0 top-0 bottom-0 border-l-2 border-gray-200" 
-          style={{ left: (msg.depth * 20) - 10 + 'px' }}
-        />
-      )}
+    <div style={{ paddingLeft: msg.depth * 20 }} className="mb-4">
       
       <div className={`flex ${msg.isOutbound ? 'justify-end' : ''}`}> 
         <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-3 max-w-[75%]">

--- a/client/src/components/MessageItem.tsx
+++ b/client/src/components/MessageItem.tsx
@@ -1,4 +1,5 @@
 // See CHANGELOG.md for 2025-06-08 [Changed]
+// See CHANGELOG.md for 2025-06-10 [Removed]
 import React, { useState } from 'react';
 import { 
   Card, 
@@ -203,7 +204,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
           
           {/* Show reply if message has been replied to */}
           {(message.status === 'replied' || message.status === 'auto-replied') && message.reply && (
-            <div className="mt-3 pl-3 border-l-2 border-gray-300 p-2">
+            <div className="mt-3 pl-3 p-2">
               <p className="text-sm text-gray-500 mb-1">
                 {message.isAiGenerated 
                   ? <Badge variant="outline" className="text-xs bg-blue-100 text-blue-900 border-blue-200 font-medium">AI Generated</Badge>

--- a/client/src/components/SimpleMessage.tsx
+++ b/client/src/components/SimpleMessage.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-10 [Removed]
 import React from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -88,8 +89,7 @@ const SimpleMessage: React.FC<SimpleMessageProps> = ({
           </div>
           
           <div className={`
-            text-sm whitespace-pre-wrap break-words text-slate-800 font-medium 
-            ${isReply ? 'border-l-2 border-l-blue-200 pl-2' : ''} 
+            text-sm whitespace-pre-wrap break-words text-slate-800 font-medium
             ${message.isOutbound ? 'bg-blue-50 rounded-lg px-3 py-2' : 'bg-white border border-gray-100 shadow-sm rounded-lg px-3 py-2'}
           `}>
             {message.content || "(No message content)"}


### PR DESCRIPTION
## Summary
- drop vertical thread connectors from ConversationThread
- remove left borders from SimpleMessage and MessageItem reply blocks
- document removal in changelog

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68487c30f22c8333af115eb3c2177813