### PR TITLE
Remove Generate Reply menu options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,4 +56,5 @@ All notable changes to this project will be documented in this file.
 - [Codex] [Changed] Desktop view now wraps long message text instead of truncating it.
 - [Codex] [Changed] Conversation thread now aligns outbound messages to the right and removes avatars for a WhatsApp-style view.
 - [Codex] [Added] Composer "Generate Reply" button populates the message input.
+- [Codex] [Changed-4] Dropdown menu now shows a grey chevron icon and only a Delete option.
 

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -14,7 +14,8 @@ import React, { useRef, useEffect, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMessageThreading, ThreadedMessageType } from '@/hooks/useMessageThreading';
 import { MessageType, ThreadType } from '@shared/schema';
-import { Loader2, Send, MoreVertical, ThumbsUp } from 'lucide-react';
+// See CHANGELOG.md for 2025-06-10 [Changed-4]
+import { Loader2, Send, ChevronDown, ThumbsUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
@@ -211,24 +212,10 @@ function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: Threade
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" size="icon" className="h-6 w-6">
-                      <MoreVertical className="h-4 w-4" />
+                      <ChevronDown className="h-4 w-4 text-gray-500" />
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent>
-                    <DropdownMenuItem onSelect={() => generateAiReply()}>
-                      {isGenerating ? (
-                        <>
-                          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                          Generating...
-                        </>
-                      ) : (
-                        <>
-                          <ThumbsUp className="h-3 w-3 mr-1" />
-                          Generate Reply
-                        </>
-                      )}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => setIsReplying(true)}>Reply</DropdownMenuItem>
                     <DropdownMenuItem onSelect={handleDelete}>Delete</DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
@@ -523,7 +510,7 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon">
-                  <MoreVertical className="h-4 w-4" />
+                  <ChevronDown className="h-4 w-4 text-gray-500" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
@@ -536,13 +523,6 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
 
       {isMobile && showMobileActions && (
         <div className="fixed top-0 left-0 right-0 bg-white border-b z-20 flex justify-end space-x-2 p-2">
-          <Button size="sm" variant="ghost" onClick={() => { showMobileActions.onGenerate(); setShowMobileActions(null); }}>
-            <ThumbsUp className="h-3 w-3 mr-1" />
-            Generate Reply
-          </Button>
-          <Button size="sm" variant="ghost" onClick={() => { showMobileActions.onReply(); setShowMobileActions(null); }}>
-            Reply
-          </Button>
           <Button size="sm" variant="ghost" onClick={() => { showMobileActions.onDelete(); setShowMobileActions(null); }}>
             Delete
           </Button>


### PR DESCRIPTION
## Summary
- dropdown menu uses a grey chevron instead of the vertical ellipsis
- remove Generate Reply and Reply from dropdown
- update CHANGELOG

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68487c8462788333b751a3bfca64ff24