### PR TITLE
Update Generate Reply button styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,6 @@ All notable changes to this project will be documented in this file.
 - [Codex] [Changed-4] Dropdown menu now shows a grey chevron icon and only a Delete option.
 - [Codex][Removed] Vertical thread lines from conversation and reply UI.
 
+### Changed
+- [Codex] Generate Reply buttons now use a robot icon with a blue background.
+

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -10,6 +10,7 @@
 // See CHANGELOG.md for 2025-06-09 [Fixed]
 // See CHANGELOG.md for 2025-06-09 [Fixed-2]
 // ===== client/src/components/ConversationThread.tsx =====
+// See CHANGELOG.md for 2025-06-10 [Changed - robot icon]
 // See CHANGELOG.md for 2025-06-08 [Fixed]
 // See CHANGELOG.md for 2025-06-08 [Added]
 import React, { useRef, useEffect, useState } from 'react';
@@ -17,7 +18,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMessageThreading, ThreadedMessageType } from '@/hooks/useMessageThreading';
 import { MessageType, ThreadType } from '@shared/schema';
 // See CHANGELOG.md for 2025-06-10 [Changed-4]
-import { Loader2, Send, ChevronDown, ThumbsUp } from 'lucide-react';
+import { Loader2, Send, ChevronDown, Bot } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
@@ -578,7 +579,7 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
           <Button
             type="button"
             aria-label="Generate AI reply"
-            className="ml-2 self-end"
+            className="ml-2 self-end bg-blue-600 hover:bg-blue-700"
             onClick={() => generateThreadReply()}
             disabled={isGeneratingThreadReply}
             data-testid="composer-generate"
@@ -586,7 +587,7 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
             {isGeneratingThreadReply ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
-              <ThumbsUp className="h-4 w-4" />
+              <Bot className="h-4 w-4 text-white" />
             )}
           </Button>
           <Button

--- a/client/src/components/MessageItem.tsx
+++ b/client/src/components/MessageItem.tsx
@@ -1,5 +1,6 @@
 // See CHANGELOG.md for 2025-06-08 [Changed]
 // See CHANGELOG.md for 2025-06-10 [Removed]
+// See CHANGELOG.md for 2025-06-10 [Changed - robot icon]
 import React, { useState } from 'react';
 import { 
   Card, 
@@ -13,9 +14,9 @@ import {
   ReplyIcon, 
   CheckCircle2, 
   AlertCircle,
-  Loader2, 
-  RefreshCw, 
-  ThumbsUp,
+  Loader2,
+  RefreshCw,
+  Bot,
   Instagram,
   Youtube
 } from "lucide-react";
@@ -258,7 +259,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
                   size="sm"
                   onClick={handleGenerateReply}
                   disabled={isGenerating || isReplying}
-                  className="bg-gray-200 hover:bg-gray-300 text-gray-900 border-gray-300"
+                  className="bg-blue-600 hover:bg-blue-700 text-white border-blue-600"
                 >
                   {isGenerating ? (
                     <>
@@ -267,7 +268,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
                     </>
                   ) : (
                     <>
-                      <ThumbsUp className="mr-2 h-4 w-4" />
+                      <Bot className="mr-2 h-4 w-4 text-white" />
                       Generate AI Reply
                     </>
                   )}


### PR DESCRIPTION
## Summary
- swap ThumbsUp icon for Bot icon
- tint Generate Reply buttons blue with a white icon
- document change in CHANGELOG

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68489d26c6108333991131f33a1e6d22