### PR TITLE
Allow custom admin test messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,4 +63,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - [Codex] Generate Reply buttons now use a robot icon with a blue background.
+### Added
+- [Codex] `/api/test/generate-for-user` accepts a `content` body so admins can send custom messages from the Tools menu.
 

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -51,14 +51,19 @@ describe('test routes', () => {
       source: 'instagram',
       metadata: {}
     })
-    const res = await fetch(`${baseUrl}/api/test/generate-for-user/${thread.id}`, { method: 'POST' })
+    const res = await fetch(`${baseUrl}/api/test/generate-for-user/${thread.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Custom test message' })
+    })
     expect(res.status).toBe(200)
     const msg = await res.json()
     expect(msg.threadId).toBe(thread.id)
     expect(msg.sender.name).toBe(thread.participantName)
     expect(msg.sender.avatar).toBeDefined()
-    expect(msg.content.length).toBeGreaterThan(0)
+    expect(msg.content).toBe('Custom test message')
     const msgs = await mem.getThreadMessages(thread.id)
-    expect(msgs.some(m => m.id === msg.id)).toBe(true)
+    const stored = msgs.find(m => m.id === msg.id)
+    expect(stored?.content).toBe('Custom test message')
   })
 })

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@
 // See CHANGELOG.md for 2025-06-09 [Added]
 // See CHANGELOG.md for 2025-06-09 [Changed]
 // See CHANGELOG.md for 2025-06-09 [Fixed]
+// See CHANGELOG.md for 2025-06-10 [Added]
 // See CHANGELOG.md for 2025-06-08 [Fixed]
 import type { Express } from "express";
 import { faker } from "@faker-js/faker";
@@ -298,6 +299,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // See CHANGELOG.md for 2025-06-10 [Added]
   app.post('/api/test/generate-for-user/:threadId', async (req, res) => {
     try {
       const threadId = parseInt(req.params.threadId);
@@ -306,12 +308,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: 'Thread not found' });
       }
 
-      const content = `Hi ${thread.participantName}, this is a test message.`;
+      const bodySchema = z.object({ content: z.string().optional() });
+      const { content } = bodySchema.parse(req.body);
 
+      const messageContent =
+        content ?? `Hi ${thread.participantName}, this is a test message.`;
 
       const rawMsg = await storage.addMessageToThread(threadId, {
         source: thread.source || 'instagram',
-        content,
+        content: messageContent,
         externalId: `faker-${Date.now()}`,
         senderId: thread.externalParticipantId,
         senderName: thread.participantName,


### PR DESCRIPTION
## Summary
- permit `/api/test/generate-for-user/:threadId` to accept a `content` body field
- add input fields in Messages and ThreadedMessages tools to send custom text
- test new endpoint capability

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68489ee138948333af22a6a7ebf24566