### PR TITLE
Update bullet format guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,11 +90,9 @@
 * **If the date already exists, append new entries under that same section.**
   ```
   ## [2025-06-05]
-  ### Added
-  - [Codex] Generated new function for match result signing in backend/server.js.
-  - [Replit Assistant] Refactored wallet connection logic in frontend/game.js for better error handling.
+  - [Codex][Added] "Generated new function for match result signing in backend/server.js."
+  - [Replit Assistant][Changed] "Refactored wallet connection logic in frontend/game.js for better error handling."
   ```
-
 ---
 
 ## Issue Reporting & Feedback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+Example entry format:
+`- [AGENT_NAME][Fixed/Changed/Added] "Description of change"`
+
 ## 2025-06-07
 - [Added] Created `CHANGELOG.md` and added contribution instructions to `README.md`.
 - [Fixed] Missing `parentMessageId` from in-memory storage caused replies to show as top-level messages.
@@ -63,6 +66,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - [Codex] Generate Reply buttons now use a robot icon with a blue background.
+- [Codex][Changed] "Updated bullet format examples in README.md, AGENTS.md, and CHANGELOG.md."
+- [Codex][Changed] "Fixed spacing after agent name in README and CHANGELOG examples."
 ### Added
 - [Codex] `/api/test/generate-for-user` accepts a `content` body so admins can send custom messages from the Tools menu.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Running `npm test` will automatically install dependencies if they are missing.
 Before making any changes, please:
 
 1. Check the latest `CHANGELOG.md` to ensure you’re not duplicating efforts.
-2. Create or update `CHANGELOG.md` with a dated entry in the correct format (`[Added]`, `[Changed]`, `[Fixed]`, `[Removed]`).
+2. Create or update `CHANGELOG.md` with a dated entry using the format:
+   `- [AGENT_NAME][Fixed/Changed/Added] "Description of change"`.
 3. Add a top-of-file comment in any source file you modify, pointing to the new changelog entry.
 4. Provide concise inline comments describing what was changed and why.
 5. Submit small, atomic commits.


### PR DESCRIPTION
## Summary
- fix bullet format spacing in README and CHANGELOG examples
- remove unnecessary heading in AGENTS example
- log doc update in changelog

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6848ad9a9aec83338f976a7cd7a74405