### PR TITLE
Fix custom message handling for generate API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,4 +65,5 @@ All notable changes to this project will be documented in this file.
 - [Codex] Generate Reply buttons now use a robot icon with a blue background.
 ### Added
 - [Codex] `/api/test/generate-for-user` accepts a `content` body so admins can send custom messages from the Tools menu.
+- [Codex][Fixed] `/api/test/generate-for-user` now correctly uses the `content` body when provided.
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@
 // See CHANGELOG.md for 2025-06-09 [Changed]
 // See CHANGELOG.md for 2025-06-09 [Fixed]
 // See CHANGELOG.md for 2025-06-10 [Added]
+// See CHANGELOG.md for 2025-06-10 [Fixed]
 // See CHANGELOG.md for 2025-06-08 [Fixed]
 import type { Express } from "express";
 import { faker } from "@faker-js/faker";
@@ -300,6 +301,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // See CHANGELOG.md for 2025-06-10 [Added]
+  // See CHANGELOG.md for 2025-06-10 [Fixed]
   app.post('/api/test/generate-for-user/:threadId', async (req, res) => {
     try {
       const threadId = parseInt(req.params.threadId);
@@ -308,8 +310,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: 'Thread not found' });
       }
 
-      const bodySchema = z.object({ content: z.string().optional() });
-      const { content } = bodySchema.parse(req.body);
+      const content =
+        typeof req.body.content === 'string' && req.body.content.trim().length > 0
+          ? req.body.content
+          : undefined;
 
       const messageContent =
         content ?? `Hi ${thread.participantName}, this is a test message.`;


### PR DESCRIPTION
## Summary
- ensure `/api/test/generate-for-user` only falls back to the default text when the content body is empty
- document the fix in CHANGELOG

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6848a8a0108083338bdfa47dc05e493b