### PR TITLE
Add privacy policy page and link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,4 +69,5 @@ Example entry format:
 - [Codex] Clarified README changelog instructions and agent guidelines for missing date sections.
 - [Codex] `/api/test/generate-for-user` accepts a `content` body so admins can send custom messages from the Tools menu.
 - [Codex][Fixed] `/api/test/generate-for-user` now correctly uses the `content` body when provided.
+- [Codex][Added] Sidebar link and new route for Privacy Policy page.
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import Settings from "@/pages/settings/Settings";
 import Analytics from "@/pages/analytics/Analytics";
 import Automation from "@/pages/automation/Automation";
 import Testing from "@/pages/testing/Testing";
+import Privacy from "@/pages/privacy/Privacy";
 
 import Sidebar from "@/components/layout/Sidebar";
 import MobileHeader from "@/components/layout/MobileHeader";
@@ -34,6 +35,7 @@ function Router() {
           <Route path="/analytics" component={Analytics} />
           <Route path="/automation" component={Automation} />
           <Route path="/testing" component={Testing} />
+          <Route path="/privacy" component={Privacy} />
           <Route component={NotFound} />
         </Switch>
       </div>

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 // See CHANGELOG.md for 2025-06-09 [Added]
+// See CHANGELOG.md for 2025-06-10 [Added]
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
 import { 
@@ -8,6 +9,7 @@ import {
   BarChart2, 
   Calendar,
   Code,
+  Lock,
 } from "lucide-react";
 
 type SidebarProps = {
@@ -97,6 +99,13 @@ const Sidebar = ({ className }: SidebarProps) => {
                 active={location === "/testing"}
               >
                 Testing Tools
+              </NavItem>
+              <NavItem
+                href="/privacy"
+                icon={<Lock />}
+                active={location === "/privacy"}
+              >
+                Privacy Policy
               </NavItem>
 
 

--- a/client/src/pages/privacy/Privacy.tsx
+++ b/client/src/pages/privacy/Privacy.tsx
@@ -1,0 +1,51 @@
+// See CHANGELOG.md for 2025-06-10 [Added]
+
+const Privacy = () => {
+  return (
+    <main className="flex-1 relative z-0 overflow-y-auto focus:outline-none md:pt-0 pt-16 px-4">
+      <div className="max-w-3xl mx-auto py-6 prose prose-neutral dark:prose-invert">
+        <h1 className="text-2xl font-bold mb-4">Privacy Policy</h1>
+        <p className="text-sm text-gray-500 mb-8">Last updated: June 12, 2025</p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">1. Information We Collect</h2>
+        <p>
+          We collect the following data when you use the app:
+          <ul className="list-disc pl-5">
+            <li>Messages sent to and from your connected Instagram account</li>
+            <li>Thread metadata like timestamps and participant IDs</li>
+            <li>Access tokens for API communication (stored securely)</li>
+            <li>Optional usage metrics (for performance monitoring)</li>
+          </ul>
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">2. How We Use Your Data</h2>
+        <p>We use your data to support AI-assisted messaging, display conversations, and perform requested actions such as reply, delete, or sync.</p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">3. Data Retention</h2>
+        <p>
+          Message data is retained for <strong>30 days</strong> by default and then permanently deleted.
+          You may also:
+          <ul className="list-disc pl-5">
+            <li>Delete an individual message</li>
+            <li>Delete a full conversation thread</li>
+            <li>Delete all your data with a single action</li>
+          </ul>
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">4. Sharing and Disclosure</h2>
+        <p>We do not sell or share your data with third parties. Data is only accessible to you and authorized services for AI processing.</p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">5. Security Practices</h2>
+        <p>Data is encrypted in transit, stored securely, and access tokens are never exposed to the frontend.</p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">6. Your Rights and Controls</h2>
+        <p>You may disconnect your account, delete any or all data, and control your data retention preferences via app settings.</p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">7. Changes to This Policy</h2>
+        <p>We may update this policy and will notify users of any material changes in the app or via email.</p>
+      </div>
+    </main>
+  );
+};
+
+export default Privacy;


### PR DESCRIPTION
## Summary
- add PrivacyPolicy page with placeholder content
- add sidebar link and routing for /privacy

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684905ba9a788333864dc4bb37488b58