### PR TITLE
Fix mobile menu auto-close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,4 +69,5 @@ Example entry format:
 - [Codex] Clarified README changelog instructions and agent guidelines for missing date sections.
 - [Codex] `/api/test/generate-for-user` accepts a `content` body so admins can send custom messages from the Tools menu.
 - [Codex][Fixed] `/api/test/generate-for-user` now correctly uses the `content` body when provided.
+- [Codex][Fixed] Mobile navigation now closes after selecting a menu item.
 

--- a/client/src/components/layout/MobileHeader.tsx
+++ b/client/src/components/layout/MobileHeader.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-10 [Fixed]
 import { useState } from "react";
 import { Link, useLocation } from "wouter";
 import { Menu } from "lucide-react";
@@ -10,6 +11,10 @@ const MobileHeader = () => {
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
+  };
+
+  const handleMenuItemClick = () => {
+    setIsMenuOpen(false);
   };
 
   return (
@@ -29,50 +34,60 @@ const MobileHeader = () => {
         {isMenuOpen && (
           <div className="bg-white pb-3 pt-2 border-b border-neutral-200 space-y-1">
             <Link href="/instagram">
-              <a className={cn(
+              <a
+                onClick={handleMenuItemClick}
+                className={cn(
                 "block px-4 py-2 text-base font-medium",
-                (location === "/" || location === "/instagram") 
-                  ? "bg-primary-50 text-primary-700" 
+                (location === "/" || location === "/instagram")
+                  ? "bg-primary-50 text-primary-700"
                   : "text-neutral-700 hover:bg-neutral-100"
               )}>
                 Instagram DMs
               </a>
             </Link>
             <Link href="/youtube">
-              <a className={cn(
+              <a
+                onClick={handleMenuItemClick}
+                className={cn(
                 "block px-4 py-2 text-base font-medium",
-                location === "/youtube" 
-                  ? "bg-primary-50 text-primary-700" 
+                location === "/youtube"
+                  ? "bg-primary-50 text-primary-700"
                   : "text-neutral-700 hover:bg-neutral-100"
               )}>
                 YouTube Comments
               </a>
             </Link>
             <Link href="/settings">
-              <a className={cn(
+              <a
+                onClick={handleMenuItemClick}
+                className={cn(
                 "block px-4 py-2 text-base font-medium",
-                location === "/settings" 
-                  ? "bg-primary-50 text-primary-700" 
+                location === "/settings"
+                  ? "bg-primary-50 text-primary-700"
                   : "text-neutral-700 hover:bg-neutral-100"
               )}>
                 Settings
               </a>
             </Link>
             <Link href="/analytics">
-              <a className={cn(
+              <a
+                onClick={handleMenuItemClick}
+                className={cn(
                 "block px-4 py-2 text-base font-medium",
-                location === "/analytics" 
-                  ? "bg-primary-50 text-primary-700" 
+                location === "/analytics"
+                  ? "bg-primary-50 text-primary-700"
                   : "text-neutral-700 hover:bg-neutral-100"
               )}>
                 Analytics
               </a>
             </Link>
             <Link href="/automation">
-              <a className={cn(
+              <a
+                onClick={handleMenuItemClick}
+                className={cn(
                 "block px-4 py-2 text-base font-medium",
-                location === "/automation" 
-                  ? "bg-primary-50 text-primary-700" 
+                location === "/automation"
+                  ? "bg-primary-50 text-primary-700"
                   : "text-neutral-700 hover:bg-neutral-100"
               )}>
                 Automation Rules


### PR DESCRIPTION
## Summary
- close the mobile menu when an item is tapped
- document the fix in the changelog

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684907bcdec0833395897f82cd3db9a7