### PR TITLE
Add ChatHeader component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,4 +69,5 @@ Example entry format:
 - [Codex] Clarified README changelog instructions and agent guidelines for missing date sections.
 - [Codex] `/api/test/generate-for-user` accepts a `content` body so admins can send custom messages from the Tools menu.
 - [Codex][Fixed] `/api/test/generate-for-user` now correctly uses the `content` body when provided.
+- [Codex][Added] `ChatHeader` component mimics WhatsApp chat header with back button and avatar.
 

--- a/client/src/components/layout/ChatHeader.test.tsx
+++ b/client/src/components/layout/ChatHeader.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ChatHeader from './ChatHeader';
+
+const sampleProps = { name: 'Liz Cell', avatarUrl: '/liz.jpg' };
+
+describe('ChatHeader', () => {
+  it('renders the user name and avatar', () => {
+    const html = renderToStaticMarkup(
+      <ChatHeader {...sampleProps} />
+    );
+    expect(html).toContain('Liz Cell');
+    expect(html).toContain('/liz.jpg');
+  });
+
+  it('includes the back arrow icon', () => {
+    const html = renderToStaticMarkup(
+      <ChatHeader {...sampleProps} />
+    );
+    expect(html.includes('svg')).toBe(true);
+  });
+});

--- a/client/src/components/layout/ChatHeader.tsx
+++ b/client/src/components/layout/ChatHeader.tsx
@@ -1,0 +1,30 @@
+// See CHANGELOG.md for 2025-06-10 [Added]
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+// Using simple image tag to ensure SSR markup includes the URL
+
+type ChatHeaderProps = {
+  name: string;
+  avatarUrl: string;
+};
+
+const ChatHeader = ({ name, avatarUrl }: ChatHeaderProps) => {
+  return (
+    <header className="flex items-center p-3 bg-[#111B21] text-white w-full">
+      <button
+        aria-label="Back"
+        className="mr-3 flex items-center justify-center text-white"
+      >
+        <ArrowLeft className="h-5 w-5" />
+      </button>
+      <img
+        src={avatarUrl}
+        alt={name}
+        className="h-8 w-8 rounded-full mr-3"
+      />
+      <span className="font-medium text-sm">{name}</span>
+    </header>
+  );
+};
+
+export default ChatHeader;


### PR DESCRIPTION
## Summary
- create `ChatHeader` with back arrow, avatar, and name
- add unit test for the component
- document update in changelog

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68490ab63e608333bfbb6a823c4b4fa2