### PR TITLE
Update generate reply endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,5 +74,6 @@ Example entry format:
 - [Codex][Fixed] Mobile conversation view no longer shows filter dropdown.
 - [Codex][Added] `ChatHeader` component mimics WhatsApp chat header with back button and avatar.
 - [Codex][Added] Sidebar link and new route for Privacy Policy page.
+- [Codex][Changed] `/api/threads/:id/generate-reply` now generates dynamic replies using user settings.
 
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -547,11 +547,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Get settings for AI parameters
       const settings = await storage.getSettings(1);
       
-      // Generate AI reply (simplified version)
-      let generatedReply = "Hi there! Thanks for reaching out. I appreciate your message and will get back to you shortly.";
-      
-      // In a real implementation, this would call the OpenAI API with thread context
-      // and use the creator's tone and preferences from settings
+      // Generate AI reply using the OpenAI service and creator settings
+      const generatedReply = await aiService.generateReply({
+        content: messages[messages.length - 1]?.content ?? "",
+        senderName: thread.participantName,
+        creatorToneDescription: settings.creatorToneDescription || "",
+        temperature: (settings.aiTemperature || 70) / 100,
+        maxLength: settings.maxResponseLength || 300,
+        flexProcessing: settings.aiSettings?.flexProcessing || false
+      });
       
       res.json({ generatedReply });
     } catch (error) {


### PR DESCRIPTION
## Summary
- call `aiService.generateReply` in `/api/threads/:id/generate-reply`
- test dynamic reply behavior
- document endpoint change in CHANGELOG

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a98b08148333a69af75a6fc936d5