### PR TITLE
Wire up AI model setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,3 +75,5 @@ Example entry format:
 - [Codex][Added] `ChatHeader` component mimics WhatsApp chat header with back button and avatar.
 - [Codex][Added] Sidebar link and new route for Privacy Policy page.
 - [Codex][Changed] `/api/threads/:id/generate-reply` now generates dynamic replies using user settings.
+- [Codex][Changed] AI Model setting now determines which OpenAI model is used for replies.
+- [Codex][Added] Unit test confirms custom model is passed to the OpenAI API.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,6 +6,7 @@
 // See CHANGELOG.md for 2025-06-10 [Fixed]
 // See CHANGELOG.md for 2025-06-08 [Fixed]
 // See CHANGELOG.md for 2025-06-11 [Changed]
+// See CHANGELOG.md for 2025-06-11 [Added]
 import type { Express } from "express";
 import { faker } from "@faker-js/faker";
 import { createServer, type Server } from "http";
@@ -555,6 +556,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         creatorToneDescription: settings.creatorToneDescription || "",
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 300,
+        model: settings.aiSettings?.model || "gpt-4o",
         flexProcessing: settings.aiSettings?.flexProcessing || false
       });
       
@@ -665,6 +667,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 300,
         contextSnippets,
+        model: settings.aiSettings?.model || "gpt-4o",
         flexProcessing: settings.aiSettings?.flexProcessing || false
       });
       
@@ -749,6 +752,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
                     creatorToneDescription: aiSettings.creatorToneDescription || "",
                     temperature: (aiSettings.temperature || 70) / 100,
                     maxLength: aiSettings.maxResponseLength || 500,
+                    model: aiSettings.model || "gpt-4o",
                     flexProcessing: aiSettings.flexProcessing || false
                   });
                   
@@ -864,6 +868,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           temperature: (settings.aiTemperature || 70) / 100, // Default to 0.7 if null
           maxLength: settings.maxResponseLength || 500, // Default to 500 if null,
           contextSnippets: useContext ? contextSnippets : undefined,
+          model: settings.aiSettings?.model || "gpt-4o",
           flexProcessing: settings.aiSettings?.flexProcessing || false
         });
       } catch (aiError: any) {
@@ -955,6 +960,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         creatorToneDescription: settings.creatorToneDescription || "",
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 500,
+        model: settings.aiSettings?.model || "gpt-4o",
         flexProcessing: settings.aiSettings?.flexProcessing || false,
       });
       
@@ -1022,6 +1028,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         temperature: (settings.aiTemperature || 70) / 100, // Default to 0.7 if null
         maxLength: settings.maxResponseLength || 500, // Default to 500 if null,
         contextSnippets: contextSnippets.length > 0 ? contextSnippets : undefined,
+        model: settings.aiSettings?.model || "gpt-4o",
         flexProcessing: settings.aiSettings?.flexProcessing || false
       });
       

--- a/server/services/openai.test.ts
+++ b/server/services/openai.test.ts
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-11 [Added]
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { AIService } from './openai'
 
@@ -35,7 +36,7 @@ describe('AIService', () => {
 
   it('generateReply returns fallback when no api key', async () => {
     process.env.OPENAI_API_KEY = ''
-    const reply = await service.generateReply({ content: 'hi', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10 })
+    const reply = await service.generateReply({ content: 'hi', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, model: 'gpt-4' })
     expect(reply).toContain('Bob')
   })
 
@@ -44,6 +45,13 @@ describe('AIService', () => {
     mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] })
     await service.generateReply({ content: 'test', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, flexProcessing: true })
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ service_tier: 'flex' }))
+  })
+
+  it('uses provided model when making OpenAI request', async () => {
+    process.env.OPENAI_API_KEY = 'test-key'
+    mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] })
+    await service.generateReply({ content: 'test', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, model: 'gpt-3.5-turbo' })
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-3.5-turbo' }))
   })
 
   it('classifyIntent parses response', async () => {

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -3,6 +3,7 @@
  * Handles interactions with OpenAI for message generation, intent classification,
  * and content moderation
  */
+// See CHANGELOG.md for 2025-06-11 [Changed]
 
 import OpenAI from "openai";
 import { storage } from "../storage";
@@ -17,6 +18,7 @@ interface GenerateReplyParams {
   creatorToneDescription: string;
   temperature: number;
   maxLength: number;
+  model?: string;
   contextSnippets?: string[]; // Additional context from content RAG pipeline
   flexProcessing?: boolean;
 }
@@ -69,7 +71,7 @@ export class AIService {
    */
   async generateReply(params: GenerateReplyParams): Promise<string> {
     try {
-      const { content, senderName, creatorToneDescription, temperature, maxLength, contextSnippets, flexProcessing } = params;
+      const { content, senderName, creatorToneDescription, temperature, maxLength, contextSnippets, flexProcessing, model } = params;
 
       // Check if OPENAI_API_KEY is available
       if (!process.env.OPENAI_API_KEY) {
@@ -119,7 +121,7 @@ export class AIService {
       `;
 
       const response = await this.openai.chat.completions.create({
-        model: DEFAULT_MODEL,
+        model: model || DEFAULT_MODEL,
         messages: [
           { role: "system", content: systemPrompt },
           { role: "user", content: userPrompt }


### PR DESCRIPTION
## Summary
- wire up AI model setting so selected model is sent to OpenAI
- test custom model usage

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849cb9517ec83339599ac0a727daa3e