### PR TITLE
Fix Generate Reply using env-loaded OpenAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,4 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Changed] `/api/threads/:id/generate-reply` now generates dynamic replies using user settings.
 - [Codex][Changed] AI Model setting now determines which OpenAI model is used for replies.
 - [Codex][Added] Unit test confirms custom model is passed to the OpenAI API.
+- [Codex][Fixed] Generate Reply now returns OpenAI content.

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,5 @@
+// See CHANGELOG.md for 2025-06-11 [Fixed]
+import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic } from "./vite";

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-11 [Fixed]
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import express from 'express'
 import type { Server } from 'http'
@@ -95,6 +96,25 @@ describe('test routes', () => {
     const data = await res.json()
     expect(mockAiService.generateReply).toHaveBeenCalled()
     expect(data.generatedReply).toBe('dynamic reply')
+
+  })
+
+  it('message generate-reply uses AI service', async () => {
+    const msg = await mem.createMessage({
+      userId: 1,
+      source: 'instagram',
+      senderId: 'u1',
+      senderName: 'User',
+      content: 'Hi',
+      externalId: 'm1',
+      metadata: {}
+    })
+    mockAiService.generateReply.mockResolvedValueOnce('dynamic reply')
+    const res = await fetch(`${baseUrl}/api/messages/${msg.id}/generate-reply`, { method: 'POST' })
+    const data = await res.json()
+    expect(res.status).toBe(200)
+    expect(data.generatedReply).toBe('dynamic reply')
+    expect(mockAiService.generateReply).toHaveBeenCalled()
 
   })
 })

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7,6 +7,7 @@
 // See CHANGELOG.md for 2025-06-08 [Fixed]
 // See CHANGELOG.md for 2025-06-11 [Changed]
 // See CHANGELOG.md for 2025-06-11 [Added]
+// See CHANGELOG.md for 2025-06-11 [Fixed]
 import type { Express } from "express";
 import { faker } from "@faker-js/faker";
 import { createServer, type Server } from "http";
@@ -638,6 +639,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Generate AI reply for any message type
   app.post('/api/messages/:id/generate-reply', async (req, res) => {
     try {
+      if (process.env.DEBUG_AI) {
+        console.debug('[DEBUG-AI] POST /api/messages/:id/generate-reply', {
+          id: req.params.id
+        });
+      }
       const messageId = parseInt(req.params.id);
       if (isNaN(messageId)) {
         return res.status(400).json({ message: 'Invalid message ID' });
@@ -670,6 +676,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         model: settings.aiSettings?.model || "gpt-4o",
         flexProcessing: settings.aiSettings?.flexProcessing || false
       });
+
+      if (process.env.DEBUG_AI) {
+        console.debug('[DEBUG-AI] generated reply', aiReply);
+      }
       
       // Return only the generated reply
       return res.json({ 

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -4,6 +4,7 @@
  * and content moderation
  */
 // See CHANGELOG.md for 2025-06-11 [Changed]
+// See CHANGELOG.md for 2025-06-11 [Fixed]
 
 import OpenAI from "openai";
 import { storage } from "../storage";
@@ -73,8 +74,15 @@ export class AIService {
     try {
       const { content, senderName, creatorToneDescription, temperature, maxLength, contextSnippets, flexProcessing, model } = params;
 
+      if (process.env.DEBUG_AI) {
+        console.debug('[DEBUG-AI] generateReply called', { senderName, model });
+      }
+
       // Check if OPENAI_API_KEY is available
       if (!process.env.OPENAI_API_KEY) {
+        if (process.env.DEBUG_AI) {
+          console.debug('[DEBUG-AI] Missing OPENAI_API_KEY, using fallback');
+        }
         log("OpenAI API key not found. Using fallback reply.");
         return this.generateFallbackReply(content, senderName);
       }
@@ -130,6 +138,10 @@ export class AIService {
         max_tokens: maxLength,
         service_tier: flexProcessing ? "flex" : undefined,
       });
+
+      if (process.env.DEBUG_AI) {
+        console.debug('[DEBUG-AI] OpenAI response', response);
+      }
 
       return response.choices[0].message.content || "Thank you for your message!";
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- load `.env` early so OpenAI API key is available
- add debug logs for generate-reply route and OpenAI service
- cover `/api/messages/:id/generate-reply` in tests

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e4d507b083338930d583b01a9d60