### PR TITLE
Fix OpenAI token lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,4 +75,5 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Added] Unit test confirms custom model is passed to the OpenAI API.
 - [Codex][Fixed] Generate Reply now returns OpenAI content.
 - [Codex][Fixed-2] Load env early in AI service so replies use OpenAI.
+- [Codex][Fixed-3] AI service now falls back to stored OpenAI tokens when env key is missing.
 


### PR DESCRIPTION
## Summary
- add `getClient` helper in AI service to fetch token from env or storage
- use `getClient` in embedding, reply, intent, and sensitivity helpers
- mock storage token in AI service tests
- log new fix in CHANGELOG

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e94b7c1083338294a0d043927aac