### PR TITLE
Remove redundant dotenv parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,6 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Fixed-3] AI service now falls back to stored OpenAI tokens when env key is missing.
 
 
+
+## 2025-06-12
+- [Codex][Changed] Removed manual dotenv parser from AI service.

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -7,20 +7,10 @@
 // See CHANGELOG.md for 2025-06-11 [Changed]
 // See CHANGELOG.md for 2025-06-11 [Fixed]
 // See CHANGELOG.md for 2025-06-11 [Fixed-3]
+// See CHANGELOG.md for 2025-06-12 [Changed]
 
-import fs from 'fs';
-
-if (!process.env.OPENAI_API_KEY) {
-  try {
-    const envContent = fs.readFileSync('.env', 'utf8');
-    for (const line of envContent.split('\n')) {
-      const match = line.match(/^([^=]+)=(.*)$/);
-      if (match && !process.env[match[1]]) {
-        process.env[match[1]] = match[2];
-      }
-    }
-  } catch {}
-}
+// dotenv/config is imported in server/index.ts before this service is
+// instantiated, so manual .env parsing is unnecessary.
 
 
 import OpenAI from "openai";


### PR DESCRIPTION
## Summary
- rely on `dotenv/config` loaded in `server/index.ts`
- remove fs-based parser from AI service
- document change in CHANGELOG

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f3a19904833399587b15ec5d73f4