### PR TITLE
Log OpenAI key updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Fixed-2] Load env early in AI service so replies use OpenAI.
 - [Codex][Added] OPENAI_API_KEY example variable.
 - [Codex][Fixed-3] AI service now falls back to stored OpenAI tokens when env key is missing.
+- [Codex][Changed-4] Warn when OpenAI API key missing and log updates to /api/settings.
 
 
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,6 +8,7 @@
 // See CHANGELOG.md for 2025-06-11 [Changed]
 // See CHANGELOG.md for 2025-06-11 [Added]
 // See CHANGELOG.md for 2025-06-11 [Fixed]
+// See CHANGELOG.md for 2025-06-11 [Changed-4]
 import type { Express } from "express";
 import { faker } from "@faker-js/faker";
 import { createServer, type Server } from "http";
@@ -1337,6 +1338,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
         if (data.apiKeys.openai !== undefined) {
           updates.openaiToken = data.apiKeys.openai;
+          log(
+            data.apiKeys.openai
+              ? 'OpenAI API key saved via settings.'
+              : 'OpenAI API key cleared via settings.'
+          );
         }
         if (data.apiKeys.airtable !== undefined) {
           updates.airtableToken = data.apiKeys.airtable;

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -8,6 +8,7 @@
 // See CHANGELOG.md for 2025-06-11 [Fixed]
 // See CHANGELOG.md for 2025-06-11 [Fixed-3]
 // See CHANGELOG.md for 2025-06-12 [Changed]
+// See CHANGELOG.md for 2025-06-11 [Changed-4]
 
 // dotenv/config is imported in server/index.ts before this service is
 // instantiated, so manual .env parsing is unnecessary.
@@ -59,7 +60,9 @@ export class AIService {
       source = "storage";
     }
 
-    if (process.env.DEBUG_AI) {
+    if (!apiKey) {
+      log("OpenAI API key not found in env or storage.");
+    } else if (process.env.DEBUG_AI) {
       console.debug(`[DEBUG-AI] Using ${source}`);
     }
 


### PR DESCRIPTION
## Summary
- warn when OpenAI key is missing
- log when `/api/settings` updates the OpenAI key

## Testing
- `npm run type-check --silent`
- `npm run lint --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6849f908d8ec8333b8ca1f261f21d2c7