### PR TITLE
Improve generateAiReply error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,7 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Added] OPENAI_API_KEY example variable.
 - [Codex][Fixed-3] AI service now falls back to stored OpenAI tokens when env key is missing.
 - [Codex][Changed-4] Warn when OpenAI API key missing and log updates to /api/settings.
-
-
+[Codex][Fixed-4] generateAiReply now checks response.ok and logs server errors.
 
 ## 2025-06-12
 - [Codex][Changed] Removed manual dotenv parser from AI service.

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-11 [Fixed-4]
 // See CHANGELOG.md for 2025-06-11 [Added]
 // See CHANGELOG.md for 2025-06-10 [Removed]
 // See CHANGELOG.md for 2025-06-10 [Changed-2]
@@ -134,6 +135,11 @@ function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: Threade
   const { mutate: generateAiReply, isPending: isGenerating } = useMutation({
     mutationFn: async () => {
       const response = await apiRequest('POST', `/api/messages/${msg.id}/generate-reply`);
+      if (!response.ok) {
+        const text = await response.text();
+        console.error(text);
+        throw new Error('Failed to generate AI reply');
+      }
       return response.json();
     },
     onSuccess: (data: any) => {
@@ -152,10 +158,10 @@ function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: Threade
         });
       }
     },
-    onError: () => {
+    onError: (error: Error) => {
       toast({
         title: 'Error generating reply',
-        description: 'There was a problem generating the AI reply.',
+        description: error.message,
         variant: 'destructive',
       });
     }


### PR DESCRIPTION
## Summary
- verify `response.ok` in `generateAiReply`
- log server text and bubble error message to user
- document change in CHANGELOG
- reference CHANGELOG from ConversationThread source

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a2a6344548333a57b434a37cedb5d