### PR TITLE
Improve AI reply error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,4 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 
 ## 2025-06-12
 - [Codex][Changed] Removed manual dotenv parser from AI service.
+- [Codex][Fixed] AI reply generation errors now show detailed messages.

--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -1,4 +1,4 @@
-// See CHANGELOG.md for 2025-06-11 [Added]
+// See CHANGELOG.md for 2025-06-12 [Fixed - detailed AI error messages]
 // See CHANGELOG.md for 2025-06-10 [Removed]
 // See CHANGELOG.md for 2025-06-10 [Changed-2]
 // See CHANGELOG.md for 2025-06-10 [Added]
@@ -152,10 +152,10 @@ function ThreadedMessage({ msg, threadId, setShowMobileActions }: { msg: Threade
         });
       }
     },
-    onError: () => {
+    onError: (error) => {
       toast({
         title: 'Error generating reply',
-        description: 'There was a problem generating the AI reply.',
+        description: error instanceof Error ? error.message : String(error),
         variant: 'destructive',
       });
     }
@@ -362,10 +362,10 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
         });
       }
     },
-    onError: () => {
+    onError: (error) => {
       toast({
         title: 'Error generating reply',
-        description: 'There was a problem generating the AI reply.',
+        description: error instanceof Error ? error.message : String(error),
         variant: 'destructive',
       });
     }

--- a/client/src/components/MessageItem.tsx
+++ b/client/src/components/MessageItem.tsx
@@ -1,6 +1,6 @@
 // See CHANGELOG.md for 2025-06-08 [Changed]
 // See CHANGELOG.md for 2025-06-10 [Removed]
-// See CHANGELOG.md for 2025-06-10 [Changed - robot icon]
+// See CHANGELOG.md for 2025-06-12 [Fixed - detailed AI error messages]
 import React, { useState } from 'react';
 import { 
   Card, 
@@ -56,7 +56,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
     onError: (error) => {
       toast({
         title: "Error sending reply",
-        description: "There was a problem sending your reply. Please try again.",
+        description: error instanceof Error ? error.message : String(error),
         variant: "destructive",
       });
     }
@@ -92,7 +92,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
       setIsGenerating(false);
       toast({
         title: "Error generating reply",
-        description: "There was a problem generating the AI reply. Please try again.",
+        description: error instanceof Error ? error.message : String(error),
         variant: "destructive",
       });
     }


### PR DESCRIPTION
## Summary
- show detailed error messages when AI reply generation fails
- reference changelog updates in ConversationThread and MessageItem

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test --silent=false` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2a64ebe0833394a34c8022bd029f