### PR TITLE
Fix keySource scope in generateReply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,4 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 ## 2025-06-12
 - [Codex][Changed] Removed manual dotenv parser from AI service.
 - [Codex][Fixed] AI reply generation errors now show detailed messages.
+- [Codex][Fixed] generateReply correctly accesses keySource across error handling.

--- a/server/services/openai.test.ts
+++ b/server/services/openai.test.ts
@@ -55,14 +55,14 @@ describe('AIService', () => {
   })
 
   it('passes flex service tier when enabled', async () => {
-    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_API_KEY = 'sk-test-key-1234567890'
     mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] })
     await service.generateReply({ content: 'test', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, flexProcessing: true })
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ service_tier: 'flex' }))
   })
 
   it('uses provided model when making OpenAI request', async () => {
-    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_API_KEY = 'sk-test-key-1234567890'
     mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] })
     await service.generateReply({ content: 'test', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, model: 'gpt-3.5-turbo' })
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-3.5-turbo' }))

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -104,6 +104,7 @@ export class AIService {
    * with contextual awareness using RAG pipeline
    */
   async generateReply(params: GenerateReplyParams): Promise<string> {
+    let keySource = "env";
     try {
       const { content, senderName, creatorToneDescription, temperature, maxLength, contextSnippets, flexProcessing, model } = params;
 
@@ -111,7 +112,8 @@ export class AIService {
         console.debug('[DEBUG-AI] generateReply called', { senderName, model });
       }
 
-      const { client, hasKey, keySource } = await this.getClient();
+      const { client, hasKey, keySource: source } = await this.getClient();
+      keySource = source;
 
       if (!hasKey) {
         if (process.env.DEBUG_AI) {


### PR DESCRIPTION
## Summary
- ensure `keySource` persists across `generateReply` error handling
- adjust OpenAI service tests for valid API key format
- document the fix in CHANGELOG

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a53463a488333ab58eb0ab79bda66