### PR TITLE
Prioritize stored OpenAI token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Fixed-3] AI service now falls back to stored OpenAI tokens when env key is missing.
 - [Codex][Changed-4] Warn when OpenAI API key missing and log updates to /api/settings.
 [Codex][Fixed-4] generateAiReply now checks response.ok and logs server errors.
+[Codex][Changed] AI service prefers stored OpenAI token over environment variable.
 
 ## 2025-06-12
 - [Codex][Changed] Removed manual dotenv parser from AI service.

--- a/server/services/openai.test.ts
+++ b/server/services/openai.test.ts
@@ -55,17 +55,21 @@ describe('AIService', () => {
   })
 
   it('passes flex service tier when enabled', async () => {
-    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_API_KEY = 'sk-valid-env-key-123456'
+    ;(storage.getSettings as any).mockResolvedValueOnce({ openaiToken: '' })
     mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] })
     await service.generateReply({ content: 'test', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, flexProcessing: true })
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ service_tier: 'flex' }))
+    expect(openaiCtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'sk-valid-env-key-123456' }))
   })
 
   it('uses provided model when making OpenAI request', async () => {
-    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_API_KEY = 'sk-valid-env-key-123456'
+    ;(storage.getSettings as any).mockResolvedValueOnce({ openaiToken: '' })
     mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] })
     await service.generateReply({ content: 'test', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, model: 'gpt-3.5-turbo' })
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-3.5-turbo' }))
+    expect(openaiCtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'sk-valid-env-key-123456' }))
   })
 
   it('classifyIntent parses response', async () => {
@@ -85,6 +89,14 @@ describe('AIService', () => {
     mockEmbeddings.create.mockResolvedValueOnce({ data: [{ embedding: [4] }] })
     const res = await service.generateEmbedding('hi')
     expect(res).toEqual([4])
+    expect(openaiCtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'stored-key' }))
+  })
+
+  it('prefers stored token over env key', async () => {
+    process.env.OPENAI_API_KEY = 'sk-valid-env-key-123456'
+    mockEmbeddings.create.mockResolvedValueOnce({ data: [{ embedding: [5] }] })
+    const res = await service.generateEmbedding('hi')
+    expect(res).toEqual([5])
     expect(openaiCtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'stored-key' }))
   })
 


### PR DESCRIPTION
## Summary
- prefer stored openaiToken over environment variable in OpenAI service
- update tests to cover new token precedence
- document change in changelog

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a538f2b388333ab8bcb6c1f42caf5