### PR TITLE
Fix mobile chat header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,3 +87,6 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Changed] Removed manual dotenv parser from AI service.
 - [Codex][Fixed] AI reply generation errors now show detailed messages.
 - [Codex][Fixed] generateReply correctly accesses keySource across error handling.
+
+## 2025-06-13
+- [Codex][Changed] Mobile conversation view now uses `ChatHeader` for WhatsApp-style back navigation.

--- a/client/src/components/layout/ChatHeader.test.tsx
+++ b/client/src/components/layout/ChatHeader.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import ChatHeader from './ChatHeader';
 
-const sampleProps = { name: 'Liz Cell', avatarUrl: '/liz.jpg' };
+const sampleProps = { name: 'Liz Cell', avatarUrl: '/liz.jpg', onBack: () => {} };
 
 describe('ChatHeader', () => {
   it('renders the user name and avatar', () => {

--- a/client/src/components/layout/ChatHeader.tsx
+++ b/client/src/components/layout/ChatHeader.tsx
@@ -6,14 +6,16 @@ import { ArrowLeft } from "lucide-react";
 type ChatHeaderProps = {
   name: string;
   avatarUrl: string;
+  onBack?: () => void;
 };
 
-const ChatHeader = ({ name, avatarUrl }: ChatHeaderProps) => {
+const ChatHeader = ({ name, avatarUrl, onBack }: ChatHeaderProps) => {
   return (
     <header className="flex items-center p-3 bg-[#111B21] text-white w-full">
       <button
         aria-label="Back"
         className="mr-3 flex items-center justify-center text-white"
+        onClick={onBack}
       >
         <ArrowLeft className="h-5 w-5" />
       </button>

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -34,6 +34,8 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 import { Input } from '@/components/ui/input';
+import ChatHeader from '@/components/layout/ChatHeader';
+import { ThreadType } from '@shared/schema';
 
 const ThreadedMessages: React.FC = () => {
   const [activeThreadId, setActiveThreadId] = useState<number | null>(null);
@@ -71,7 +73,7 @@ const ThreadedMessages: React.FC = () => {
   }, [activeThreadId]);
   
   // Get active thread info
-  const [activeThreadData, setActiveThreadData] = useState(null);
+  const [activeThreadData, setActiveThreadData] = useState<ThreadType | null>(null);
 
   // Handle thread selection
   const handleThreadSelect = (threadId: number, threadData: any = null) => {
@@ -165,18 +167,11 @@ const ThreadedMessages: React.FC = () => {
           ) : (
             // Conversation view for mobile with back button
             <div className="h-full flex flex-col">
-              <div className="px-4 py-2 border-b flex items-center sticky top-0 bg-white z-10">
-                <Button 
-                  variant="default"
-                  size="sm" 
-                  className="bg-gray-800 hover:bg-gray-900 text-white mr-3"
-                  onClick={handleBackClick}
-                >
-                  <ArrowLeft className="h-4 w-4 mr-1" />
-                  Back to Threads
-                </Button>
-                <h2 className="font-semibold">Conversation</h2>
-              </div>
+              <ChatHeader
+                name={activeThreadData?.participantName || 'Conversation'}
+                avatarUrl={activeThreadData?.participantAvatar || ''}
+                onBack={handleBackClick}
+              />
               <div className="flex-1 overflow-auto">
                 {activeThreadId && (
                   <ConversationThread


### PR DESCRIPTION
## Summary
- wire up `ChatHeader` in mobile conversation view
- allow an `onBack` prop for the header
- update tests
- document change

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac2a4c4e48333973ce7995db7bbb7