### PR TITLE
Refactor chat menu layout

### DIFF
--- a/client/src/components/ConversationThread.tsx
+++ b/client/src/components/ConversationThread.tsx
@@ -493,58 +493,6 @@ const ConversationThread: React.FC<ConversationThreadProps> = ({
   
   return (
     <div className="flex flex-col h-full">
-      {/* Thread header with participant info */}
-      {threadData && (
-        <div className="px-4 py-3 border-b flex items-center bg-white">
-          {showBackButton && onBack && (
-            <Button variant="ghost" size="sm" onClick={onBack} className="mr-2">
-              ←
-            </Button>
-          )}
-          <div className="flex items-center">
-            <div
-              className={`w-10 h-10 rounded-full mr-3 flex-shrink-0 overflow-hidden ring-2 ${
-                threadData.isHighIntent ? 'ring-orange-500' : 'ring-gray-300'
-              } bg-gray-200`}
-            >
-              {threadData.participantAvatar ? (
-                <img
-                  src={threadData.participantAvatar}
-                  alt={threadData.participantName}
-                  className="w-full h-full object-cover" 
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-gray-500 font-medium">
-                  {threadData.participantName.substring(0, 1).toUpperCase()}
-                </div>
-              )}
-            </div>
-            <div>
-              <h3 className="font-medium">{threadData.participantName}</h3>
-              <div className="text-xs text-gray-500 flex items-center">
-                <span className="capitalize">{threadData.source}</span>
-                {threadData.isHighIntent && (
-                  <span className="ml-2 px-1.5 py-0.5 bg-amber-100 text-amber-800 rounded text-xs font-medium">
-                    High Intent
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
-          <div className="ml-auto">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon">
-                  <ChevronDown className="h-4 w-4 text-gray-500" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onSelect={() => deleteThread()}>Delete Thread</DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-      )}
 
       {isMobile && showMobileActions && (
         <div className="fixed top-0 left-0 right-0 bg-white border-b z-20 flex justify-end space-x-2 p-2">

--- a/client/src/components/layout/ChatHeader.test.tsx
+++ b/client/src/components/layout/ChatHeader.test.tsx
@@ -1,22 +1,29 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ChatHeader from './ChatHeader';
 
-const sampleProps = { name: 'Liz Cell', avatarUrl: '/liz.jpg', onBack: () => {} };
+const sampleProps = { name: 'Liz Cell', avatarUrl: '/liz.jpg', platform: 'instagram', onBack: () => {} };
 
 describe('ChatHeader', () => {
   it('renders the user name and avatar', () => {
+    const client = new QueryClient();
     const html = renderToStaticMarkup(
-      <ChatHeader {...sampleProps} />
+      <QueryClientProvider client={client}>
+        <ChatHeader {...sampleProps} />
+      </QueryClientProvider>
     );
     expect(html).toContain('Liz Cell');
     expect(html).toContain('/liz.jpg');
   });
 
   it('includes the back arrow icon', () => {
+    const client = new QueryClient();
     const html = renderToStaticMarkup(
-      <ChatHeader {...sampleProps} />
+      <QueryClientProvider client={client}>
+        <ChatHeader {...sampleProps} />
+      </QueryClientProvider>
     );
     expect(html.includes('svg')).toBe(true);
   });

--- a/client/src/components/layout/ChatHeader.tsx
+++ b/client/src/components/layout/ChatHeader.tsx
@@ -1,21 +1,125 @@
 // See CHANGELOG.md for 2025-06-12 [Changed]
 import React, { useState } from "react";
 import { Link } from "wouter";
-import { ArrowLeft, Menu } from "lucide-react";
+import { ArrowLeft, Menu, FileQuestion, RefreshCw, Link2 } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
 // Using simple image tag to ensure SSR markup includes the URL
 
 type ChatHeaderProps = {
   name?: string;
   avatarUrl?: string;
+  platform?: string;
   onBack?: () => void;
+  onDeleteThread?: () => void;
 };
 
-const ChatHeader = ({ name = "", avatarUrl = "", onBack }: ChatHeaderProps) => {
+const ChatHeader = ({
+  name = "",
+  avatarUrl = "",
+  platform = "",
+  onBack,
+  onDeleteThread,
+}: ChatHeaderProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { data: threads = [] } = useQuery({ queryKey: ["/api/threads"] });
+  const [customThreadId, setCustomThreadId] = useState("");
+  const [customMessage, setCustomMessage] = useState("");
+
+  const handleGenerateBatch = () => {
+    fetch("/api/test/generate-batch", { method: "POST" })
+      .then(res => {
+        if (!res.ok) {
+          return res.text().then(t => {
+            throw new Error(`Server error: ${t}`);
+          });
+        }
+        return res.json();
+      })
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["/api/instagram/messages"] });
+        queryClient.invalidateQueries({ queryKey: ["/api/youtube/messages"] });
+        toast({ title: "Batch generated", description: "10 messages created" });
+      })
+      .catch(err => {
+        console.error("Batch error:", err);
+        toast({ title: "Error", description: String(err), variant: "destructive" });
+      });
+  };
+
+  const handleSendCustom = () => {
+    if (!customThreadId) return;
+    fetch(`/api/test/generate-for-user/${customThreadId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: customMessage }),
+    })
+      .then(res => {
+        if (!res.ok) {
+          return res.text().then(t => {
+            throw new Error(`Server error: ${t}`);
+          });
+        }
+        return res.json();
+      })
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["/api/threads"] });
+        toast({
+          title: "Message generated",
+          description: `Message added to thread ${customThreadId}`,
+        });
+        setCustomMessage("");
+      })
+      .catch(err => {
+        console.error("Generate error:", err);
+        toast({ title: "Error", description: String(err), variant: "destructive" });
+      });
+  };
+
+  const handleReloadDatabase = () => {
+    toast({
+      title: "Database Refresh",
+      description: "Refreshing messages from database...",
+    });
+    queryClient.invalidateQueries({ queryKey: ["/api/instagram/messages"] });
+    queryClient.invalidateQueries({ queryKey: ["/api/youtube/messages"] });
+  };
+
+  const handleReloadCache = () => {
+    toast({
+      title: "Cache Refresh",
+      description: "Clearing frontend cache and refreshing data...",
+    });
+    queryClient.invalidateQueries();
+  };
+
+  const handleSetupWebhook = async () => {
+    try {
+      const res = await fetch("/api/instagram/setup-webhook", { method: "POST" });
+      const data = await res.json();
+      if (res.ok) {
+        toast({ title: "Webhook Setup", description: "Instagram webhook successfully configured" });
+      } else {
+        toast({ title: "Webhook Setup Failed", description: data.message || "Failed to set up Instagram webhook", variant: "destructive" });
+      }
+    } catch (error) {
+      toast({ title: "Webhook Setup Error", description: "An error occurred during webhook setup", variant: "destructive" });
+    }
+  };
 
   return (
-    <>
-      <header className="md:hidden flex items-center justify-between p-3 bg-[#111B21] text-white w-full">
+    <div className="relative md:hidden">
+      <header className="flex items-center justify-between p-3 bg-[#111B21] text-white w-full">
         <div className="flex items-center">
           {onBack && (
             <button
@@ -29,7 +133,16 @@ const ChatHeader = ({ name = "", avatarUrl = "", onBack }: ChatHeaderProps) => {
           {avatarUrl && (
             <img src={avatarUrl} alt={name} className="h-8 w-8 rounded-full mr-3" />
           )}
-          {name && <span className="font-medium text-sm">{name}</span>}
+          {name && (
+            <span className="font-medium text-sm flex items-center">
+              {name}
+              {platform && (
+                <span className="ml-2 bg-neutral-700 text-xs px-1.5 py-0.5 rounded capitalize">
+                  {platform}
+                </span>
+              )}
+            </span>
+          )}
         </div>
         <button
           aria-label="Menu"
@@ -41,25 +154,77 @@ const ChatHeader = ({ name = "", avatarUrl = "", onBack }: ChatHeaderProps) => {
       </header>
 
       {menuOpen && (
-        <div className="md:hidden bg-[#111B21] text-white pb-3 pt-2 border-b border-neutral-700 space-y-1">
-          <Link href="/instagram">
-            <a className="block px-4 py-2 text-base">Instagram DMs</a>
+        <div className="absolute right-0 mt-2 w-2/5 max-w-sm bg-white text-black shadow-md rounded-md p-4 space-y-2 z-20">
+          {onDeleteThread && (
+            <>
+              <div className="font-medium text-sm">Thread Actions</div>
+              <Button
+                variant="ghost"
+                className="w-full justify-start"
+                onClick={() => {
+                  onDeleteThread();
+                  setMenuOpen(false);
+                }}
+              >
+                Delete Thread
+              </Button>
+              <hr className="border-t border-gray-200 my-2" />
+            </>
+          )}
+          <div className="font-medium text-sm">Tools</div>
+          <Button className="w-full mb-2" onClick={handleGenerateBatch}>
+            <FileQuestion className="h-4 w-4 mr-2" /> Generate Batch Messages
+          </Button>
+          <Select onValueChange={id => setCustomThreadId(id)} value={customThreadId}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Generate For Thread" />
+            </SelectTrigger>
+            <SelectContent className="max-h-60 overflow-y-auto">
+              {Array.isArray(threads) &&
+                (threads as any[]).map((thread: any) => (
+                  <SelectItem key={thread.id} value={String(thread.id)}>
+                    {thread.participantName}
+                  </SelectItem>
+                ))}
+            </SelectContent>
+          </Select>
+          <input
+            className="mt-2 w-full border border-gray-300 rounded px-2 py-1 text-sm"
+            placeholder="Custom message"
+            value={customMessage}
+            onChange={e => setCustomMessage(e.target.value)}
+          />
+          <Button className="w-full mt-2" onClick={handleSendCustom}>
+            Send Custom Message
+          </Button>
+          <Button className="w-full mt-2" variant="outline" onClick={handleReloadDatabase}>
+            <RefreshCw className="h-4 w-4 mr-2" /> Reload - database
+          </Button>
+          <Button className="w-full mt-2" variant="outline" onClick={handleReloadCache}>
+            <RefreshCw className="h-4 w-4 mr-2" /> Reload - frontend cache
+          </Button>
+          <Button className="w-full mt-2" variant="outline" onClick={handleSetupWebhook}>
+            <Link2 className="h-4 w-4 mr-2" /> Setup Webhook
+          </Button>
+          <hr className="border-t border-gray-200 my-2" />
+          <Link href="/instagram" className="block px-4 py-2 text-sm hover:bg-gray-100 rounded">
+            Instagram DMs
           </Link>
-          <Link href="/youtube">
-            <a className="block px-4 py-2 text-base">YouTube Comments</a>
+          <Link href="/youtube" className="block px-4 py-2 text-sm hover:bg-gray-100 rounded">
+            YouTube Comments
           </Link>
-          <Link href="/settings">
-            <a className="block px-4 py-2 text-base">Settings</a>
+          <Link href="/settings" className="block px-4 py-2 text-sm hover:bg-gray-100 rounded">
+            Settings
           </Link>
-          <Link href="/analytics">
-            <a className="block px-4 py-2 text-base">Analytics</a>
+          <Link href="/analytics" className="block px-4 py-2 text-sm hover:bg-gray-100 rounded">
+            Analytics
           </Link>
-          <Link href="/automation">
-            <a className="block px-4 py-2 text-base">Automation Rules</a>
+          <Link href="/automation" className="block px-4 py-2 text-sm hover:bg-gray-100 rounded">
+            Automation Rules
           </Link>
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -27,15 +27,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Loader2, SearchX, ChevronDown, ArrowLeft, FileQuestion, RefreshCw, Link2 } from 'lucide-react';
+import { Loader2, SearchX, ChevronDown, ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
-import { Input } from '@/components/ui/input';
+
+
 import ChatHeader from '@/components/layout/ChatHeader';
 import MobileHeader from '@/components/layout/MobileHeader';
 import { ThreadType } from '@shared/schema';
@@ -48,8 +43,6 @@ const ThreadedMessages: React.FC = () => {
   const [showThreadList, setShowThreadList] = useState(true);
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [customThreadId, setCustomThreadId] = useState('');
-  const [customMessage, setCustomMessage] = useState('');
   
   // Check for mobile view on mount and on resize
   useEffect(() => {
@@ -118,6 +111,21 @@ const ThreadedMessages: React.FC = () => {
       setShowThreadList(true);
     }
   };
+
+  const handleDeleteThread = async () => {
+    if (!activeThreadId) return;
+    try {
+      const res = await fetch(`/api/threads/${activeThreadId}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed');
+      queryClient.setQueryData<ThreadType[]>(['/api/threads'], (old) => old?.filter(t => t.id !== activeThreadId) || []);
+      queryClient.invalidateQueries({ queryKey: ['/api/threads'] });
+      toast({ title: 'Thread deleted' });
+      setActiveThreadId(null);
+      setActiveThreadData(null);
+    } catch {
+      toast({ title: 'Failed to delete thread', variant: 'destructive' });
+    }
+  };
   
   // Check for empty threads
   const { data: threads, isLoading, error } = useQuery({
@@ -174,7 +182,9 @@ const ThreadedMessages: React.FC = () => {
               <ChatHeader
                 name={activeThreadData?.participantName || 'Conversation'}
                 avatarUrl={activeThreadData?.participantAvatar || ''}
+                platform={activeThreadData?.source || ''}
                 onBack={handleBackClick}
+                onDeleteThread={handleDeleteThread}
               />
               <div className="flex-1 overflow-auto">
                 {activeThreadId && (
@@ -265,167 +275,7 @@ const ThreadedMessages: React.FC = () => {
       <div className="p-4 border-b border-gray-200 bg-white">
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-2xl font-bold">Messages</h1>
-          <div className="flex items-center space-x-2">
-            <div className="relative">
-              <Accordion type="single" collapsible>
-                <AccordionItem value="tools">
-                  <AccordionTrigger className="bg-gray-900 text-white px-4 py-2 rounded flex items-center h-9 border-gray-900 hover:bg-gray-800">
-                    <FileQuestion className="h-4 w-4 mr-2" />
-                    Tools
-                  </AccordionTrigger>
-                  <AccordionContent className="absolute right-0 z-10 mt-1 bg-white border border-gray-200 shadow-lg rounded w-64">
-                    <div className="px-4 py-3">
-                      <Button
-                        className="w-full mb-2 bg-gray-900 text-white hover:bg-gray-800 border-gray-900"
-                        onClick={() => {
-                          fetch('/api/test/generate-batch', { method: 'POST' })
-                            .then(res => {
-                              if (!res.ok) {
-                                return res.text().then(t => { throw new Error(`Server error: ${t}`); });
-                              }
-                              return res.json();
-                            })
-                            .then(() => {
-                              queryClient.invalidateQueries({ queryKey: ['/api/instagram/messages'] });
-                              queryClient.invalidateQueries({ queryKey: ['/api/youtube/messages'] });
-                              toast({ title: 'Batch generated', description: '10 messages created' });
-                            })
-                            .catch(err => {
-                              console.error('Batch error:', err);
-                              toast({ title: 'Error', description: String(err), variant: 'destructive' });
-                            });
-                        }}
-                      >
-                        Generate Batch Messages
-                      </Button>
-                      <Select
-                        onValueChange={(id) => setCustomThreadId(id)}
-                        value={customThreadId}
-                      >
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Generate For Thread" />
-                        </SelectTrigger>
-                        <SelectContent className="max-h-60 overflow-y-auto">
-                          {Array.isArray(threads) &&
-                            threads.map((thread: any) => (
-                              <SelectItem key={thread.id} value={String(thread.id)}>
-                                {thread.participantName}
-                              </SelectItem>
-                            ))}
-                        </SelectContent>
-                      </Select>
-                      <Input
-                        className="mt-2"
-                        placeholder="Custom message"
-                        value={customMessage}
-                        onChange={(e) => setCustomMessage(e.target.value)}
-                      />
-                      <Button
-                        className="w-full mt-2"
-                        onClick={() => {
-                          if (!customThreadId) return;
-                          fetch(`/api/test/generate-for-user/${customThreadId}`, {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ content: customMessage })
-                          })
-                            .then(res => {
-                              if (!res.ok) {
-                                return res.text().then(t => { throw new Error(`Server error: ${t}`); });
-                              }
-                              return res.json();
-                            })
-                            .then(() => {
-                              queryClient.invalidateQueries({ queryKey: ['/api/threads'] });
-                              toast({ title: 'Message generated', description: `Message added to thread ${customThreadId}` });
-                              setCustomMessage('');
-                            })
-                            .catch(err => {
-                              console.error('Generate error:', err);
-                              toast({ title: 'Error', description: String(err), variant: 'destructive' });
-                            });
-                        }}
-                      >
-                        Send Custom Message
-                      </Button>
-                      {/* Database refresh replicates Testing Tools page */}
-                      <Button
-                        className="w-full mt-2"
-                        variant="outline"
-                        onClick={() => {
-                          toast({
-                            title: 'Database Refresh',
-                            description: 'Refreshing messages from database...'
-                          });
-                          // Refetch messages directly from storage
-                          queryClient.invalidateQueries({ queryKey: ['/api/instagram/messages'] });
-                          queryClient.invalidateQueries({ queryKey: ['/api/youtube/messages'] });
-                        }}
-                      >
-                        <RefreshCw className="h-4 w-4 mr-2" />
-                        Reload - database
-                      </Button>
-                      {/* Clear frontend cache for fresh data */}
-                      <Button
-                        className="w-full mt-2"
-                        variant="outline"
-                        onClick={() => {
-                          toast({
-                            title: 'Cache Refresh',
-                            description: 'Clearing frontend cache and refreshing data...'
-                          });
-                          // Invalidate all cached queries
-                          queryClient.invalidateQueries();
-                        }}
-                      >
-                        <RefreshCw className="h-4 w-4 mr-2" />
-                        Reload - frontend cache
-                      </Button>
-                      {/* Setup Instagram webhook for real-time updates */}
-                      <Button
-                        className="w-full mt-2"
-                        variant="outline"
-                        onClick={() => {
-                          const setupWebhook = async () => {
-                            try {
-                              const response = await fetch('/api/instagram/setup-webhook', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' }
-                              });
-                              const data = await response.json();
-
-                              if (response.ok) {
-                                toast({
-                                  title: 'Webhook Setup',
-                                  description: 'Instagram webhook successfully configured'
-                                });
-                              } else {
-                                toast({
-                                  title: 'Webhook Setup Failed',
-                                  description: data.message || 'Failed to set up Instagram webhook',
-                                  variant: 'destructive'
-                                });
-                              }
-                            } catch (error) {
-                              toast({
-                                title: 'Webhook Setup Error',
-                                description: 'An error occurred during webhook setup',
-                                variant: 'destructive'
-                              });
-                            }
-                          };
-                          setupWebhook();
-                        }}
-                      >
-                        <Link2 className="h-4 w-4 mr-2" />
-                        Setup Webhook
-                      </Button>
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </div>
-          </div>
+          <div className="flex items-center space-x-2"></div>
         </div>
         {/* Desktop tabs */}
         <div className="hidden md:block">


### PR DESCRIPTION
## Summary
- move thread delete & tools into mobile ChatHeader menu
- show channel badge beside name in ChatHeader
- remove conversation profile row
- adjust ThreadedMessages to use new header props
- update ChatHeader tests for React Query

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ad7406c388333af0c61f24d8d8285