### PR TITLE
Implement content item storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,4 +106,5 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 [Codex][Changed] ChatHeader displayed on mobile conversation view only.
 - [Codex][Added] DEBUG_AI logs around batch message generation for troubleshooting.
 
-
+## 2025-06-13
+- [Codex][Added] Content item storage and vector search.

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -1,17 +1,18 @@
 
 // See CHANGELOG.md for 2025-06-11 [Added]
 // See CHANGELOG.md for 2025-06-13 [Added]
-import { 
-  messages, 
-  users, 
-  settings, 
-  automationRules, 
-  leads, 
+import {
+  messages,
+  users,
+  settings,
+  automationRules,
+  leads,
   analytics,
   messageThreads,
-  type User, 
-  type InsertUser, 
-  type Message, 
+  contentItems,
+  type User,
+  type InsertUser,
+  type Message,
   type InsertMessage,
   type Settings,
   type InsertSettings,
@@ -25,7 +26,9 @@ import {
   type SenderType,
   type MessageThread,
   type InsertMessageThread,
-  type ThreadType
+  type ThreadType,
+  type InsertContentItem,
+  type ContentItem
 } from "@shared/schema";
 import { db } from "./db";
 import { eq, desc, and, inArray, sql } from "drizzle-orm";
@@ -266,14 +269,21 @@ export class DatabaseStorage implements IStorage {
   }
 
   // Content methods for RAG pipeline
-  async createContentItem(contentItem: any): Promise<any> {
-    // Implementation will be added later for RAG pipeline
-    return contentItem;
+  async createContentItem(contentItem: InsertContentItem): Promise<ContentItem> {
+    const [item] = await db
+      .insert(contentItems)
+      .values(contentItem)
+      .returning();
+
+    return item;
   }
-  
+
   async findSimilarContent(userId: number, embedding: number[], limit: number): Promise<string[]> {
-    // Implementation will be added later for RAG pipeline
-    return [];
+    const vector = `[${embedding.join(',')}]`;
+    const result = await db.execute(
+      sql`SELECT ${contentItems.content} FROM ${contentItems} WHERE ${contentItems.userId} = ${userId} ORDER BY ${contentItems.embedding} <-> ${vector} LIMIT ${limit}`
+    );
+    return result.rows.map((r: any) => r.content as string);
   }
   
   // User methods


### PR DESCRIPTION
## Summary
- insert content items into the database
- support vector similarity queries
- mirror vector search in in-memory storage

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b3fcbb1a48333856bdd2548e0de7c