### PR TITLE
Update env var docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,4 +106,8 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 [Codex][Changed] ChatHeader displayed on mobile conversation view only.
 - [Codex][Added] DEBUG_AI logs around batch message generation for troubleshooting.
 
+## 2025-06-13
+
+- [Codex][Added] Documented DATABASE_URL, OPENAI_API_KEY, and other server environment variables in README.
+
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ This project powers an avatar messenger application built with Node.js and React
 
 Create a `.env` file with the following variables:
 
+- `DATABASE_URL` – PostgreSQL connection string for the server database
+- `OPENAI_API_KEY` – API key used when generating AI replies
 - `INSTAGRAM_APP_ID` – Facebook App ID for Instagram OAuth
 - `INSTAGRAM_APP_SECRET` – Facebook App Secret for Instagram OAuth
+- `INSTAGRAM_VERIFY_TOKEN` – Token used to validate incoming Instagram webhooks
 - `VITE_INSTAGRAM_APP_ID` – Front-end copy of `INSTAGRAM_APP_ID`
+- `WEBHOOK_BASE_URL` – Base URL for constructing webhook callbacks
+
+The test suite expects these environment variables (or suitable mocks) to be present when running `npm test`.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- note all server env vars in README
- document that tests expect env vars

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b4086b654833394bb3649579e1ffd