### PR TITLE
Add content search endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,4 +106,8 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 [Codex][Changed] ChatHeader displayed on mobile conversation view only.
 - [Codex][Added] DEBUG_AI logs around batch message generation for troubleshooting.
 
+## 2025-06-14
+
+- [Codex][Added] `/api/content/search` endpoint for embedding-based content lookup.
+
 


### PR DESCRIPTION
## Summary
- add `/api/content/search` route to query content via embedding distance
- document new route in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b4061bb70833383cd1c78ed02bad2