### PR TITLE
Fix mobile chat header visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 [Codex][Changed] ChatHeader displayed on mobile conversation view only.
 - [Codex][Added] DEBUG_AI logs around batch message generation for troubleshooting.
 - [Codex][Added] Migration adds PGVector extension and `content_items` table.
+- [Codex][Fixed] ChatHeader now shows on mobile when selecting a thread.
 
 ## 2025-06-13
 - [Codex][Added] Content item storage and vector search.


### PR DESCRIPTION
## Summary
- ensure mobile chat header shows when selecting a thread
- keep `activeThreadData` in sync with the active thread
- document fix in changelog

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b454c8f308333b1a1c63ff4d793fb