### PR TITLE
Add AI auto-reply label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,6 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Added] Documented DATABASE_URL, OPENAI_API_KEY, and other server environment variables in README.
 - [Codex][Added] /api/content/search endpoint and ranking tests.
 - [Codex][Added] Content item storage and vector search.
+
+## 2025-06-13
+- [Codex][Added] Auto-reply label for AI responses.

--- a/client/src/components/MessageItem.test.tsx
+++ b/client/src/components/MessageItem.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import MessageItem from './MessageItem';
+import { MessageType } from '@shared/schema';
+
+const baseMessage: MessageType = {
+  id: 1,
+  source: 'instagram',
+  content: 'Hi there',
+  sender: { id: 'u1', name: 'User' },
+  timestamp: new Date('2025-06-01T00:00:00Z').toISOString(),
+  status: 'auto-replied',
+  isHighIntent: false,
+  isAiGenerated: true,
+  isOutbound: true,
+  reply: 'Hello',
+  isAutoReply: true,
+};
+
+describe('MessageItem', () => {
+  it('shows AI Reply label when isAutoReply is true', () => {
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <MessageItem message={baseMessage} />
+      </QueryClientProvider>
+    );
+    expect(html).toContain('AI Reply');
+  });
+});

--- a/client/src/components/MessageItem.tsx
+++ b/client/src/components/MessageItem.tsx
@@ -16,7 +16,7 @@ import {
   AlertCircle,
   Loader2,
   RefreshCw,
-  Bot,
+  Bot as BotIcon,
   Instagram,
   Youtube
 } from "lucide-react";
@@ -169,7 +169,15 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
   };
 
   return (
-    <div className={`w-full border-b border-gray-200 p-4 ${message.isHighIntent ? "border-l-4 border-l-amber-500" : ""}`}>
+    <div
+      className={`relative w-full border-b border-gray-200 p-4 ${message.isHighIntent ? "border-l-4 border-l-amber-500" : ""}`}
+    >
+      {message.isAutoReply && (
+        <div className="absolute top-1 right-2 flex items-center gap-1 text-xs text-muted-foreground">
+          <BotIcon className="w-3 h-3" />
+          <span>AI Reply</span>
+        </div>
+      )}
       <div className="flex items-start">
         <Avatar className="h-10 w-10 mr-3 flex-shrink-0">
           <AvatarImage src={message.sender.avatar} alt={message.sender.name} />
@@ -268,7 +276,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ message }) => {
                     </>
                   ) : (
                     <>
-                      <Bot className="mr-2 h-4 w-4 text-white" />
+                      <BotIcon className="mr-2 h-4 w-4 text-white" />
                       Generate AI Reply
                     </>
                   )}

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -373,7 +373,8 @@ export class DatabaseStorage implements IStorage {
         threadId: msg.threadId ?? undefined,
       parentMessageId: parentId,
       isOutbound: msg.isOutbound || false,
-      isAiGenerated: msg.isAiGenerated || false
+      isAiGenerated: msg.isAiGenerated || false,
+      isAutoReply: msg.status === 'auto-replied'
     };
   }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -437,7 +437,8 @@ export class MemStorage {
       threadId: msg.threadId ?? undefined,
       parentMessageId: parentId,
       isOutbound: msg.isOutbound || false,
-      isAiGenerated: msg.isAiGenerated ?? false
+      isAiGenerated: msg.isAiGenerated ?? false,
+      isAutoReply: msg.status === 'auto-replied'
     };
   }
 
@@ -792,29 +793,6 @@ export class MemStorage {
     });
     scored.sort((a, b) => b.score - a.score);
     return scored.slice(0, limit).map(s => s.item.content);
-    const cosine = (a: number[], b: number[]) => {
-      let dot = 0;
-      let magA = 0;
-      let magB = 0;
-      for (let i = 0; i < a.length; i++) {
-        dot += a[i] * b[i];
-        magA += a[i] * a[i];
-        magB += b[i] * b[i];
-      }
-      return dot / (Math.sqrt(magA) * Math.sqrt(magB));
-    };
-
-    const items = Array.from(this.contentItems.values()).filter(
-      item => item.userId === userId,
-    );
-
-    items.sort(
-      (a, b) =>
-        cosine(b.embedding as number[], embedding) -
-        cosine(a.embedding as number[], embedding),
-    );
-
-    return items.slice(0, limit).map(i => i.content);
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -215,6 +215,8 @@ export interface MessageType {
   reply?: string;
   isAiGenerated?: boolean;
   isOutbound?: boolean;
+  // True if the message was automatically sent by the AI system
+  isAutoReply?: boolean;
   parentMessageId?: number;
 }
 


### PR DESCRIPTION
## Summary
- extend `MessageType` with `isAutoReply`
- map auto replies in memory & DB storage
- show `AI Reply` label on message bubbles
- test label rendering

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b59b025848333ac9310ef26bf1218