### PR TITLE
Add auto-reply update endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,9 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Added] Documented DATABASE_URL, OPENAI_API_KEY, and other server environment variables in README.
 - [Codex][Added] /api/content/search endpoint and ranking tests.
 - [Codex][Added] Content item storage and vector search.
+
+## 2025-06-14
+
+[Codex][Added] Thread auto-reply patch route with storage update.
+[Codex][Added] autoReply field to MessageThread schema.
+[Codex][Fixed] Removed duplicate variable in findSimilarContent.

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -129,4 +129,25 @@ describe('test routes', () => {
     expect(data.results).toEqual(['c'])
     expect(mockContentService.retrieveRelevantContent).toHaveBeenCalledWith('test', 1, 5)
   })
+
+  it('updates thread auto-reply flag', async () => {
+    const thread = await mem.createThread({
+      userId: 1,
+      externalParticipantId: 'u',
+      participantName: 'User',
+      source: 'instagram',
+      metadata: {}
+    })
+
+    const res = await fetch(`${baseUrl}/api/threads/${thread.id}/auto-reply`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ autoReply: true })
+    })
+    const data = await res.json()
+    expect(res.status).toBe(200)
+    expect(data.autoReply).toBe(true)
+    const stored = await mem.getThread(thread.id)
+    expect((stored as any).autoReply).toBe(true)
+  })
 })

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -607,6 +607,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.patch('/api/threads/:id/auto-reply', async (req, res) => {
+    try {
+      const threadId = parseInt(req.params.id);
+      const schema = z.object({ autoReply: z.boolean() });
+      const { autoReply } = schema.parse(req.body);
+
+      const updatedThread = await storage.updateThread(threadId, { autoReply } as any);
+      if (!updatedThread) {
+        return res.status(404).json({ message: 'Thread not found' });
+      }
+      res.json(updatedThread);
+    } catch (error) {
+      console.error('Error updating thread auto-reply:', error);
+      res.status(500).json({ message: 'Failed to update thread auto-reply' });
+    }
+  });
+
   app.delete('/api/threads/:id', async (req, res) => {
     try {
       const threadId = parseInt(req.params.id);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -784,14 +784,6 @@ export class MemStorage {
     limit: number,
   ): Promise<string[]> {
 
-    const items = Array.from(this.contentItems.values()).filter(i => i.userId === userId);
-    const scored = items.map(item => {
-      const emb = item.embedding || [];
-      const score = emb.reduce((acc, val, idx) => acc + val * (embedding[idx] || 0), 0);
-      return { item, score };
-    });
-    scored.sort((a, b) => b.score - a.score);
-    return scored.slice(0, limit).map(s => s.item.content);
     const cosine = (a: number[], b: number[]) => {
       let dot = 0;
       let magA = 0;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -25,6 +25,7 @@ export const messageThreads = pgTable("message_threads", {
   lastMessageAt: timestamp("last_message_at").defaultNow().notNull(),
   lastMessageContent: text("last_message_content"),
   status: text("status").default("active"), // 'active', 'archived', 'snoozed'
+  autoReply: boolean("auto_reply").default(false),
   unreadCount: integer("unread_count").default(0),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   metadata: jsonb("metadata"),


### PR DESCRIPTION
## Summary
- support updating a thread's auto-reply setting via `/api/threads/:id/auto-reply`
- expose `autoReply` on message threads
- fix duplicate variable in `findSimilarContent`
- test auto-reply route
- document changes in CHANGELOG

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b5998b16c833392f5dc8611b36827