### PR TITLE
Thread-based auto-reply checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Added] Auto-reply label for AI responses.
 [Codex][Added] Per-thread AI reply toggle and PATCH endpoint.
 [Codex][Fixed] Auto-reply schema cleanup and patch route response shape.
+[Codex][Changed] Instagram webhook checks thread `autoReply` before sending AI replies.
 
 ## 2025-06-16
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -12,6 +12,7 @@
 // See CHANGELOG.md for 2025-06-13 [Added]
 // See CHANGELOG.md for 2025-06-11 [Changed-4]
 // See CHANGELOG.md for 2025-06-14 [Added]
+// See CHANGELOG.md for 2025-06-12 [Changed-2]
 import type { Express } from "express";
 import { faker } from "@faker-js/faker";
 import { createServer, type Server } from "http";
@@ -796,13 +797,14 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
                 };
                 
                 // Process and store the message
-                const savedMessage = await instagramService.processNewMessage(instagramMessage, 1);
+                const { message: savedMessage, thread } =
+                  await instagramService.processNewMessage(instagramMessage, 1);
                 
                 // Check if auto-reply is enabled
                 const settings = await storage.getSettings(1);
                 const aiSettings = settings.aiSettings as any;
 
-                if (aiSettings?.autoReplyInstagram) {
+                if (aiSettings?.autoReplyInstagram && thread.autoReply) {
                   // Generate AI reply
                   const aiReply = await aiService.generateReply({
                     content: instagramMessage.message,

--- a/server/services/instagram.test.ts
+++ b/server/services/instagram.test.ts
@@ -1,17 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+// See CHANGELOG.md for 2025-06-12 [Changed]
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
+import type { Server } from 'http'
+import express from 'express'
+import { MemStorage } from '../storage'
 
-vi.mock('../storage', () => ({
-  storage: {
-    getSettings: vi.fn().mockResolvedValue({ apiKeys: { instagram: 'token' } }),
-    createMessage: vi.fn().mockResolvedValue({ id: 1 }),
-    getAnalytics: vi.fn().mockResolvedValue({ instagramMsgCount: 0, newMsgCount: 0 }),
-    updateAnalytics: vi.fn().mockResolvedValue({})
+var mem: MemStorage
+vi.mock('../storage', async () => {
+  const actual = await vi.importActual<typeof import('../storage')>('../storage')
+  mem = new actual.MemStorage()
+  return { ...actual, storage: mem }
+})
+var mockAiService: any
+vi.mock('./openai', () => {
+  mockAiService = {
+    classifyIntent: vi
+      .fn()
+      .mockResolvedValue({
+        isHighIntent: false,
+        confidence: 0.5,
+        category: 'general',
+      }),
+    generateReply: vi.fn(),
   }
-}))
-vi.mock('./openai', () => ({ aiService: { classifyIntent: vi.fn().mockResolvedValue({ isHighIntent: false, confidence: 0.5, category: 'general' }) } }))
+  return { aiService: mockAiService }
+})
 
 import { InstagramService } from './instagram'
 const service = new InstagramService()
+
+beforeEach(async () => {
+  await mem.updateSettings(1, { apiKeys: { instagram: 'token' } })
+})
 
 describe('InstagramService', () => {
   it('fetchMessages returns success', async () => {
@@ -27,11 +46,123 @@ describe('InstagramService', () => {
   it('processNewMessage stores message', async () => {
     const msg = { id: '1', from: { id: 'u', username: 'name' }, message: 'hi', timestamp: new Date().toISOString() }
     const res = await service.processNewMessage(msg as any, 1)
-    expect(res).toEqual({ id: 1 })
+    expect(res.message.threadId).toBe(res.thread.id)
+    expect(res.message.content).toBe('hi')
   })
 
   it('setupWebhook returns success', async () => {
     const res = await service.setupWebhook('http://cb', 1)
     expect(res.success).toBe(true)
+  })
+})
+
+describe('Instagram webhook auto-reply', () => {
+  let server: any
+  let baseUrl: string
+  beforeAll(async () => {
+    const { registerRoutes } = await import('../routes')
+    const express = (await import('express')).default
+    const app = express()
+    app.use(express.json())
+    server = await registerRoutes(app)
+    await new Promise(resolve => server.listen(0, resolve))
+    const addr = server.address()
+    baseUrl = `http://127.0.0.1:${addr.port}`
+    await mem.updateSettings(1, { aiAutoRepliesInstagram: true, aiSettings: { autoReplyInstagram: true } })
+  })
+
+  afterAll(() => {
+    server?.close()
+  })
+
+  beforeEach(() => {
+    mockAiService.generateReply.mockReset()
+  })
+
+  it('triggers auto-reply when thread flag enabled', async () => {
+    vi.spyOn(mem, 'findOrCreateThreadByParticipant').mockResolvedValueOnce({
+      id: 2,
+      userId: 1,
+      externalParticipantId: 'u1',
+      participantName: 'u',
+      source: 'instagram',
+      createdAt: new Date(),
+      lastMessageAt: new Date(),
+      unreadCount: 0,
+      status: 'active',
+      autoReply: true,
+      metadata: {},
+    } as any)
+    vi.spyOn(mem, 'addMessageToThread').mockResolvedValueOnce({
+      id: 5,
+      threadId: 2,
+    } as any)
+    mockAiService.generateReply.mockResolvedValueOnce('ok')
+
+    const payload = {
+      object: 'instagram',
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: 'u1' },
+              message: { mid: 'm1', text: 'hi' },
+              timestamp: Date.now(),
+            },
+          ],
+        },
+      ],
+    }
+
+    const res = await fetch(`${baseUrl}/webhook/instagram`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    expect(res.status).toBe(200)
+    expect(mockAiService.generateReply).toHaveBeenCalled()
+  })
+
+  it('skips auto-reply when thread flag disabled', async () => {
+    vi.spyOn(mem, 'findOrCreateThreadByParticipant').mockResolvedValueOnce({
+      id: 3,
+      userId: 1,
+      externalParticipantId: 'u1',
+      participantName: 'u',
+      source: 'instagram',
+      createdAt: new Date(),
+      lastMessageAt: new Date(),
+      unreadCount: 0,
+      status: 'active',
+      autoReply: false,
+      metadata: {},
+    } as any)
+    vi.spyOn(mem, 'addMessageToThread').mockResolvedValueOnce({
+      id: 6,
+      threadId: 3,
+    } as any)
+
+    const payload = {
+      object: 'instagram',
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: 'u1' },
+              message: { mid: 'm2', text: 'hi' },
+              timestamp: Date.now(),
+            },
+          ],
+        },
+      ],
+    }
+
+    const res = await fetch(`${baseUrl}/webhook/instagram`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    expect(res.status).toBe(200)
+    expect(mockAiService.generateReply).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- thread-aware Instagram message processing returns message + thread
- Instagram webhook respects per-thread auto-reply flag
- schema & tests reflect new behavior
- changelog update

## Testing
- `npm run type-check`
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684b762edd808333863a5897d23c43db