### PR TITLE
Enable auto-reply for custom messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 [Codex][Added] Per-thread AI reply toggle and PATCH endpoint.
 [Codex][Fixed] Auto-reply schema cleanup and patch route response shape.
 [Codex][Changed] Instagram webhook checks thread `autoReply` before sending AI replies.
+[Codex][Changed] Custom messages trigger AI auto-reply when settings allow.
 
 ## 2025-06-16
 


### PR DESCRIPTION
## Summary
- trigger auto-reply when a custom message is posted if settings allow
- query settings in `ThreadedMessages` page
- log when auto-reply is triggered
- document the new behavior in CHANGELOG

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ba180216c8333afb2d02b52cf631f