### PR TITLE
feat(messages): improve auto-reply debug and settings fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,4 +127,10 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 
 [Codex][Fixed] Send Custom Message now auto-replies after settings load.
 
+## 2025-06-17
+
+- [Codex][Changed] Send Custom Message button waits for settings cache before enabling.
+- [Codex][Added] Deep debug trace in Messages mutation when auto-reply triggers.
+- [Codex][Fixed] Fallback fetch ensures AI settings exist before evaluating channel flags.
+
 


### PR DESCRIPTION
## Summary
- add deep debug trace inside Messages onSuccess
- disable custom message send until settings cache is ready
- fetch settings inside onSuccess if missing and re-evaluate channel flag
- document the behavior in CHANGELOG

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bb449b480833380633c1770fbb344