### PR TITLE
Fix AI auto-reply in test route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,8 @@ Follow the instructions in [Changelog Guide](CHANGELOG_GUIDE.md) to update this 
 - [Codex][Fixed] Fallback fetch ensures AI settings exist before evaluating channel flags.
 
 
+
+2025-06-13
+- [Codex][Fixed] Test route now triggers AI auto-reply when enabled.
+- [Codex][Added] Coverage for auto-reply in generate-for-user route.
+


### PR DESCRIPTION
## Summary
- trigger auto-reply for `/api/test/generate-for-user/:threadId`
- cover auto-reply path in server tests
- document the behavior change in CHANGELOG

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c377c4b2083338b82df9f6fa1ad5b