### PR TITLE
Add mobile custom message action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,10 +186,15 @@ CHANGLOG.md file.
 - [Codex][Changed] Send Custom Message button waits for settings cache before
   enabling.
 - [Codex][Added] Deep debug trace in Messages mutation when auto-reply triggers.
-- [Codex][Fixed] Fallback fetch ensures AI settings exist before evaluating channel flags.
+- [Codex][Fixed] Fallback fetch ensures AI settings exist before evaluating
+  channel flags.
 - [Codex][Fixed] Fallback fetch ensures AI settings exist before evaluating
   channel flags.
 - [Codex][Fixed] Test route now triggers AI auto-reply when enabled.
 - [Codex][Added] Coverage for auto-reply in generate-for-user route.
 - [Codex][Fixed] Mobile ChatHeader menu shows actions even without callbacks.
 - [Codex][Added] Unit test for custom message auto-reply.
+
+## 2025-06-14
+
+- [Codex][Added] ChatHeader menu generates custom message for active thread.

--- a/client/src/components/layout/ChatHeader.tsx
+++ b/client/src/components/layout/ChatHeader.tsx
@@ -1,7 +1,7 @@
 // See CHANGELOG.md for 2025-06-14 [Changed - removed tools menu on mobile]
+// See CHANGELOG.md for 2025-06-14 [Added - generate custom message action]
 import React, { useState } from "react";
-import { Link } from "wouter";
-import { ArrowLeft, Menu, Trash2 } from "lucide-react";
+import { ArrowLeft, Menu, Trash2, MessageSquarePlus } from "lucide-react";
 // Using simple image tag to ensure SSR markup includes the URL
 
 type ChatHeaderProps = {
@@ -10,6 +10,7 @@ type ChatHeaderProps = {
   platform?: string;
   onBack?: () => void;
   onDeleteThread?: () => void;
+  onGenerateCustomMessage?: () => void;
 };
 
 const ChatHeader = ({
@@ -18,8 +19,10 @@ const ChatHeader = ({
   platform = "",
   onBack,
   onDeleteThread,
+  onGenerateCustomMessage,
 }: ChatHeaderProps) => {
   const handleDeleteThread = onDeleteThread ?? (() => {});
+  const handleGenerateCustomMessage = onGenerateCustomMessage ?? (() => {});
 
   if (typeof window !== "undefined" && (window as any).DEBUG_AI) {
     console.debug("[DEBUG-AI] ChatHeader render", {
@@ -90,6 +93,16 @@ const ChatHeader = ({
               >
                 <Trash2 className="w-4 h-4 text-red-500" />
                 <span>Delete Thread</span>
+              </button>
+              <button
+                className="flex items-center space-x-2 w-full text-left py-2 my-1 font-medium text-gray-900 rounded-md hover:bg-gray-100 focus:outline-none focus:bg-gray-200 min-h-[44px] px-1"
+                onClick={() => {
+                  handleGenerateCustomMessage();
+                  setMenuOpen(false);
+                }}
+              >
+                <MessageSquarePlus className="w-4 h-4 text-blue-500" />
+                <span>Generate Custom Message</span>
               </button>
             </div>
             <div className="border-t border-gray-200 my-2" />

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -12,6 +12,7 @@
 // See CHANGELOG.md for 2025-06-12 [Changed - show ChatHeader only in conversation view]
 // See CHANGELOG.md for 2025-06-13 [Removed - Messages page header]
 // See CHANGELOG.md for 2025-06-12 [Fixed - mobile header visibility]
+// See CHANGELOG.md for 2025-06-14 [Added - header generate message]
 import React, { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ThreadList from "@/components/ThreadList";
@@ -68,6 +69,36 @@ const ThreadedMessages: React.FC = () => {
   const [activeThreadData, setActiveThreadData] = useState<ThreadType | null>(
     null,
   );
+
+  const handleGenerateCustomMessage = () => {
+    if (!activeThreadId) return;
+    fetch(`/api/test/generate-for-user/${activeThreadId}`, {
+      method: "POST",
+    })
+      .then((res) => {
+        if (!res.ok) {
+          return res.text().then((t) => {
+            throw new Error(`Server error: ${t}`);
+          });
+        }
+        return res.json();
+      })
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["/api/threads"] });
+        toast({
+          title: "Message generated",
+          description: `Message added to thread ${activeThreadId}`,
+        });
+      })
+      .catch((err) => {
+        console.error("Generate error:", err);
+        toast({
+          title: "Error",
+          description: String(err),
+          variant: "destructive",
+        });
+      });
+  };
 
 
   // Check for mobile view on mount and on resize
@@ -221,6 +252,7 @@ const ThreadedMessages: React.FC = () => {
                   avatarUrl={activeThreadData.participantAvatar}
                   platform={activeThreadData.source}
                   onBack={() => setShowThreadList(true)}
+                  onGenerateCustomMessage={handleGenerateCustomMessage}
                 />
               )}
               <div className="flex-1 overflow-auto">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
+import typography from "@tailwindcss/typography";
 
 export default {
   darkMode: ["class"],
@@ -86,5 +88,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
+  plugins: [tailwindcssAnimate, typography],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- extend `ChatHeader` props for generating a custom message
- support custom message generation from `ThreadedMessages`
- show `Generate Custom Message` in the ChatHeader menu
- migrate Tailwind config imports
- document changes in CHANGELOG

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684c9aa189ec8333b071b91e4460ee95