### PR TITLE
Add custom message textbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,3 +198,5 @@ CHANGLOG.md file.
 ## 2025-06-14
 
 - [Codex][Added] ChatHeader menu generates custom message for active thread.
+- [Codex][Changed] Burger menu includes textbox to send custom message; button
+  disabled when empty.

--- a/client/src/components/layout/ChatHeader.tsx
+++ b/client/src/components/layout/ChatHeader.tsx
@@ -1,7 +1,9 @@
 // See CHANGELOG.md for 2025-06-14 [Changed - removed tools menu on mobile]
 // See CHANGELOG.md for 2025-06-14 [Added - generate custom message action]
+// See CHANGELOG.md for 2025-06-14 [Added - custom message textbox]
 import React, { useState } from "react";
 import { ArrowLeft, Menu, Trash2, MessageSquarePlus } from "lucide-react";
+import { Input } from "@/components/ui/input";
 // Using simple image tag to ensure SSR markup includes the URL
 
 type ChatHeaderProps = {
@@ -10,7 +12,7 @@ type ChatHeaderProps = {
   platform?: string;
   onBack?: () => void;
   onDeleteThread?: () => void;
-  onGenerateCustomMessage?: () => void;
+  onGenerateCustomMessage?: (msg: string) => void;
 };
 
 const ChatHeader = ({
@@ -23,6 +25,7 @@ const ChatHeader = ({
 }: ChatHeaderProps) => {
   const handleDeleteThread = onDeleteThread ?? (() => {});
   const handleGenerateCustomMessage = onGenerateCustomMessage ?? (() => {});
+  const [customMsg, setCustomMsg] = useState("");
 
   if (typeof window !== "undefined" && (window as any).DEBUG_AI) {
     console.debug("[DEBUG-AI] ChatHeader render", {
@@ -95,15 +98,23 @@ const ChatHeader = ({
                 <span>Delete Thread</span>
               </button>
               <button
-                className="flex items-center space-x-2 w-full text-left py-2 my-1 font-medium text-gray-900 rounded-md hover:bg-gray-100 focus:outline-none focus:bg-gray-200 min-h-[44px] px-1"
+                className={`flex items-center space-x-2 w-full text-left py-2 my-1 font-medium text-gray-900 rounded-md hover:bg-gray-100 focus:outline-none focus:bg-gray-200 min-h-[44px] px-1 ${!customMsg.trim() ? "opacity-50 cursor-not-allowed" : ""}`}
+                disabled={!customMsg.trim()}
                 onClick={() => {
-                  handleGenerateCustomMessage();
+                  handleGenerateCustomMessage(customMsg);
                   setMenuOpen(false);
+                  setCustomMsg("");
                 }}
               >
                 <MessageSquarePlus className="w-4 h-4 text-blue-500" />
                 <span>Generate Custom Message</span>
               </button>
+              <Input
+                className="mt-1"
+                placeholder="Custom message"
+                value={customMsg}
+                onChange={(e) => setCustomMsg(e.target.value)}
+              />
             </div>
             <div className="border-t border-gray-200 my-2" />
           </div>

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -70,10 +70,12 @@ const ThreadedMessages: React.FC = () => {
     null,
   );
 
-  const handleGenerateCustomMessage = () => {
+  const handleGenerateCustomMessage = (msg: string) => {
     if (!activeThreadId) return;
     fetch(`/api/test/generate-for-user/${activeThreadId}`, {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: msg }),
     })
       .then((res) => {
         if (!res.ok) {
@@ -252,7 +254,7 @@ const ThreadedMessages: React.FC = () => {
                   avatarUrl={activeThreadData.participantAvatar}
                   platform={activeThreadData.source}
                   onBack={() => setShowThreadList(true)}
-                  onGenerateCustomMessage={handleGenerateCustomMessage}
+                  onGenerateCustomMessage={(m) => handleGenerateCustomMessage(m)}
                 />
               )}
               <div className="flex-1 overflow-auto">


### PR DESCRIPTION
## Summary
- extend ChatHeader with a textbox in the menu for generating custom messages
- wire message handler in ThreadedMessages to accept the custom text
- document the new behavior in the changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca10910048333a522eaaa45717a8d