### PR TITLE
Fix batch generation to create threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,8 @@ CHANGLOG.md file.
 - [Codex][Fixed] Mobile ChatHeader menu shows actions even without callbacks.
 - [Codex][Added] Unit test for custom message auto-reply.
 
+[Codex][Fixed-2] Batch messages now create threads and refresh the thread list.
+
 ## 2025-06-14
 
 - [Codex][Added] ChatHeader menu generates custom message for active thread.

--- a/client/src/pages/messages/Messages.tsx
+++ b/client/src/pages/messages/Messages.tsx
@@ -6,6 +6,7 @@
 // See CHANGELOG.md for 2025-06-09 [Changed - thread dropdown]
 // See CHANGELOG.md for 2025-06-10 [Fixed - batch invalidation keys]
 // See CHANGELOG.md for 2025-06-10 [Added]
+// See CHANGELOG.md for 2025-06-13 [Fixed-2]
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import MessageItem from "@/components/MessageItem";
@@ -213,6 +214,7 @@ const Messages = () => {
                             .then(() => {
                               queryClient.invalidateQueries({ queryKey: ['/api/instagram/messages'] });
                               queryClient.invalidateQueries({ queryKey: ['/api/youtube/messages'] });
+                              queryClient.invalidateQueries({ queryKey: ['/api/threads'] });
                               toast({ title: 'Batch generated', description: '10 messages created' });
                             })
                             .catch(err => {

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -9,6 +9,7 @@
 // See CHANGELOG.md for 2025-06-10 [Added]
 // See CHANGELOG.md for 2025-06-10 [Fixed - hide mobile filter dropdown in conversation view]
 // See CHANGELOG.md for 2025-06-12 [Changed - mobile header integrates menu]
+// See CHANGELOG.md for 2025-06-13 [Fixed-2]
 // See CHANGELOG.md for 2025-06-12 [Changed - show ChatHeader only in conversation view]
 // See CHANGELOG.md for 2025-06-13 [Removed - Messages page header]
 // See CHANGELOG.md for 2025-06-12 [Fixed - mobile header visibility]
@@ -376,6 +377,9 @@ const ThreadedMessages: React.FC = () => {
                               });
                               queryClient.invalidateQueries({
                                 queryKey: ["/api/youtube/messages"],
+                              });
+                              queryClient.invalidateQueries({
+                                queryKey: ["/api/threads"],
                               });
                               toast({
                                 title: "Batch generated",

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1,6 +1,7 @@
 // See CHANGELOG.md for 2025-06-11 [Fixed]
 // See CHANGELOG.md for 2025-06-14 [Added]
 // See CHANGELOG.md for 2025-06-13 [Added]
+// See CHANGELOG.md for 2025-06-13 [Fixed-2]
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import express from 'express'
 import type { Server } from 'http'
@@ -40,13 +41,16 @@ afterAll(() => {
 
 describe('test routes', () => {
   it('generate-batch creates messages', async () => {
-    const before = (mem as any).msgs.size || 0
+    const beforeMsgs = (mem as any).msgs.size || 0
+    const beforeThreads = (mem as any).threads.size || 0
     const res = await fetch(`${baseUrl}/api/test/generate-batch`, { method: 'POST' })
     expect(res.status).toBe(200)
     const data = await res.json()
     expect(data.count).toBe(10)
-    const after = (mem as any).msgs.size || 0
-    expect(after - before).toBe(10)
+    const afterMsgs = (mem as any).msgs.size || 0
+    const afterThreads = (mem as any).threads.size || 0
+    expect(afterMsgs - beforeMsgs).toBe(10)
+    expect(afterThreads - beforeThreads).toBeGreaterThanOrEqual(10)
     const messages = Array.from((mem as any).msgs.values()).slice(-10)
     const hi = messages.filter((m: any) => m.isHighIntent)
     expect(hi.length).toBeGreaterThanOrEqual(3)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -19,6 +19,7 @@ import type { Express } from "express";
 import { faker } from "@faker-js/faker";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
+// See CHANGELOG.md for 2025-06-13 [Fixed-2]
 import { db } from "./db";
 import { z } from "zod";
 import { messages } from "@shared/schema";
@@ -284,20 +285,32 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       for (let i = 0; i < 10; i++) {
-        const isHighIntent = highIntentIndexes.has(i);
-        const source = Math.random() > 0.5 ? 'instagram' : 'youtube';
+        const isHighIntent = highIntentIndexes.has(i)
+        const source = Math.random() > 0.5 ? 'instagram' : 'youtube'
 
         if (process.env.DEBUG_AI) {
-          console.debug('[DEBUG-AI] creating message', { index: i, isHighIntent, source });
+          console.debug('[DEBUG-AI] creating message', { index: i, isHighIntent, source })
         }
 
-        const message = await storage.createMessage({
+        const senderId = faker.internet.userName().toLowerCase()
+        const senderName = faker.person.fullName()
+        const senderAvatar = faker.image.avatar()
+
+        const thread = await storage.findOrCreateThreadByParticipant(
+          1,
+          senderId,
+          senderName,
+          source,
+          senderAvatar
+        )
+
+        const message = await storage.addMessageToThread(thread.id, {
           source,
           content: faker.lorem.sentence(),
           externalId: `faker-${Date.now()}-${i}`,
-          senderId: faker.internet.userName().toLowerCase(),
-          senderName: faker.person.fullName(),
-          senderAvatar: faker.image.avatar(),
+          senderId,
+          senderName,
+          senderAvatar,
           timestamp: new Date(),
           status: 'new',
           isHighIntent,
@@ -306,13 +319,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
             ? faker.number.int({ min: 80, max: 100 })
             : undefined,
           userId: 1,
-        });
+          metadata: {},
+        })
 
         if (process.env.DEBUG_AI) {
-          console.debug('[DEBUG-AI] created message', { id: message.id });
+          console.debug('[DEBUG-AI] created message', { id: message.id, threadId: thread.id })
         }
 
-        messages.push(message);
+        messages.push(message)
       }
 
       if (process.env.DEBUG_AI) {


### PR DESCRIPTION
## Summary
- ensure Generate Batch Messages creates message threads
- refresh thread queries after batch generation
- test batch route for thread creation

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ca22e66288333a2db91b28c303a25