### PR TITLE
Add AI response delay control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@ CHANGLOG.md file.
 - [Codex][Added] Coverage for auto-reply in generate-for-user route.
 - [Codex][Fixed] Mobile ChatHeader menu shows actions even without callbacks.
 - [Codex][Added] Unit test for custom message auto-reply.
+- [Codex][Added] Configurable response delay for automated AI replies.
 
 ## 2025-06-14
 

--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -1,3 +1,4 @@
+// See CHANGELOG.md for 2025-06-13 [Added-2]
 import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
@@ -34,6 +35,7 @@ interface SettingsData {
     autoReplyInstagram: boolean;
     autoReplyYoutube: boolean;
     flexProcessing: boolean;
+    responseDelay: number;
   };
   notificationSettings: {
     email: string;
@@ -67,6 +69,7 @@ const Settings = () => {
       autoReplyInstagram: false,
       autoReplyYoutube: false,
       flexProcessing: false,
+      responseDelay: 0,
     },
     notificationSettings: {
       email: "",
@@ -441,6 +444,20 @@ const Settings = () => {
                           aiSettings: { ...settings.aiSettings, flexProcessing: checked }
                         })}
                       />
+                    </div>
+                    <div className="space-y-2 mt-3">
+                      <Label htmlFor="response-delay">Automated AI Response Delay (seconds)</Label>
+                      <Input
+                        id="response-delay"
+                        type="number"
+                        min={0}
+                        value={settings.aiSettings.responseDelay}
+                        onChange={(e) => setSettings({
+                          ...settings,
+                          aiSettings: { ...settings.aiSettings, responseDelay: Number(e.target.value) }
+                        })}
+                      />
+                      <p className="text-xs text-neutral-500">Set to 0 for instant replies.</p>
                     </div>
                   </div>
                 </CardContent>

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -3,6 +3,7 @@
 // See CHANGELOG.md for 2025-06-13 [Added]
 // See CHANGELOG.md for 2025-06-14 [Added]
 // See CHANGELOG.md for 2025-06-12 [Fixed]
+// See CHANGELOG.md for 2025-06-13 [Added-2]
 import { 
   messages, 
   users, 
@@ -453,7 +454,8 @@ export class DatabaseStorage implements IStorage {
         model: "gpt-4o",
         autoReplyInstagram: false,
         autoReplyYoutube: false,
-        flexProcessing: false
+        flexProcessing: false,
+        responseDelay: 0
       },
       notificationSettings: {
         email: "",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -13,6 +13,7 @@
 // See CHANGELOG.md for 2025-06-13 [Fixed]
 // See CHANGELOG.md for 2025-06-11 [Changed-4]
 // See CHANGELOG.md for 2025-06-14 [Added]
+// See CHANGELOG.md for 2025-06-13 [Added-2]
 // See CHANGELOG.md for 2025-06-12 [Changed-2]
 // See CHANGELOG.md for 2025-06-17 [Changed]
 import type { Express } from "express";
@@ -850,6 +851,10 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
                   });
                   
                   // Send reply to Instagram
+                  const delaySec = aiSettings.responseDelay || 0;
+                  if (delaySec > 0) {
+                    await new Promise((r) => setTimeout(r, delaySec * 1000));
+                  }
                   await instagramService.sendReply(instagramMessage.id, aiReply);
                   
                   // Update message status
@@ -974,6 +979,10 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
       
       // Send reply to Instagram (in a real app, this would use the actual Instagram API)
       try {
+        const delaySec = settings.aiSettings?.responseDelay || 0;
+        if (delaySec > 0) {
+          await new Promise((r) => setTimeout(r, delaySec * 1000));
+        }
         await instagramService.sendReply(message.externalId, aiReply);
       } catch (instagramError) {
         log("Note: Instagram reply simulation - would fail in production app");
@@ -1058,6 +1067,10 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
       });
       
       // Send reply to YouTube
+      const delaySec = settings.aiSettings?.responseDelay || 0;
+      if (delaySec > 0) {
+        await new Promise((r) => setTimeout(r, delaySec * 1000));
+      }
       await youtubeService.sendReply(message.externalId, aiReply);
       
       // Update message status
@@ -1346,7 +1359,8 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
           model: settings.aiModel || "gpt-4o",
           autoReplyInstagram: settings.aiAutoRepliesInstagram || false,
           autoReplyYoutube: settings.aiAutoRepliesYoutube || false,
-          flexProcessing: false
+          flexProcessing: false,
+          responseDelay: 0
         };
       }
       
@@ -1388,6 +1402,7 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
           autoReplyInstagram: z.boolean().optional(),
           autoReplyYoutube: z.boolean().optional(),
           flexProcessing: z.boolean().optional(),
+          responseDelay: z.number().min(0).optional(),
         }).optional(),
         notificationSettings: z.object({
           email: z.string().email().optional(),

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -3,6 +3,7 @@
 // [Fixed] 2025-06-10 - high-intent threads are now flagged correctly
 // See CHANGELOG.md for 2025-06-13 [Added]
 // See CHANGELOG.md for 2025-06-12 [Fixed]
+// See CHANGELOG.md for 2025-06-13 [Added-2]
 import {
   messages, 
   users, 
@@ -145,7 +146,7 @@ export class MemStorage {
       id: 1,
       userId: 1,
       apiKeys: {},
-      aiSettings: { flexProcessing: false },
+      aiSettings: { flexProcessing: false, responseDelay: 0 },
       notificationSettings: {},
       aiAutoRepliesInstagram: false,
       aiAutoRepliesYoutube: false,
@@ -609,7 +610,7 @@ export class MemStorage {
         id: this.settingsId++,
         userId,
         apiKeys: {},
-        aiSettings: { flexProcessing: false },
+        aiSettings: { flexProcessing: false, responseDelay: 0 },
         notificationSettings: {},
         aiAutoRepliesInstagram: false,
         aiAutoRepliesYoutube: false,


### PR DESCRIPTION
## Summary
- allow customizing AI auto reply delay via new setting field
- persist response delay in memory/database
- update /api/settings schema
- respect delay when sending automated replies

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684ca87741fc8333a0227ce711dc3715