### PR TITLE
Add ToolsDrawer and unify desktop tools UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,3 +203,10 @@ CHANGLOG.md file.
 
 - [Codex][Changed] Adjust AI Replies row layout in `ThreadRow` for a tighter
   grouping.
+
+## 2025-06-17
+
+- [Codex][Changed] Desktop Tools dropdown replaced with drawer on md+ screens.
+- [Codex][Added] Unit tests ensure Tools drawer opens, focuses input, and closes
+  with ESC.
+- [Codex][Changed] README updated for Tools drawer usage.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ everyone.
 Open the **Testing Tools** page from the sidebar when running the dev server.
 Use **Generate Batch Messages** to create 10 demo messages (at least three
 flagged high intent). Use **Generate For Thread** to add a fake incoming message
-to a specific thread ID. The Tools dropdown has returned to the Messages page
-header for quick access, but the dedicated Testing Tools page remains available.
+to a specific thread ID. The Messages page now shows a desktop-only **Tools
+drawer**, opened via the wrench icon. The dedicated Testing Tools page remains
+available.
 
 ## Continuous Integration
 

--- a/client/src/components/ToolsDrawer.test.tsx
+++ b/client/src/components/ToolsDrawer.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ToolsDrawer from './ToolsDrawer'
+import type { MessageThread } from '@shared/schema'
+
+const threads: MessageThread[] = [
+  {
+    id: 1,
+    createdAt: new Date(),
+    userId: 1,
+    externalParticipantId: '1',
+    participantName: 'Demo',
+    participantAvatar: null,
+    source: 'instagram',
+    lastMessageAt: new Date(),
+    lastMessageContent: null,
+    status: 'active',
+    autoReply: false,
+    unreadCount: 0,
+    metadata: {}
+  }
+]
+
+describe('ToolsDrawer', () => {
+  it('focuses input when opened and closes on ESC', async () => {
+    const onClose = vi.fn()
+    render(
+      <ToolsDrawer
+        open={true}
+        onClose={onClose}
+        onGenerateBatch={vi.fn()}
+        threads={threads}
+        customThreadId=""
+        setCustomThreadId={() => {}}
+        customMessage=""
+        setCustomMessage={() => {}}
+        onSendCustom={vi.fn()}
+        canSend
+        onReloadDb={vi.fn()}
+        onClearCache={vi.fn()}
+        onSetupWebhook={vi.fn()}
+      />
+    )
+    const input = screen.getByPlaceholderText('Custom message')
+    expect(document.activeElement).toBe(input)
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls handlers when buttons clicked', async () => {
+    const onGenerateBatch = vi.fn()
+    render(
+      <ToolsDrawer
+        open={true}
+        onClose={() => {}}
+        onGenerateBatch={onGenerateBatch}
+        threads={threads}
+        customThreadId=""
+        setCustomThreadId={() => {}}
+        customMessage=""
+        setCustomMessage={() => {}}
+        onSendCustom={vi.fn()}
+        canSend
+        onReloadDb={vi.fn()}
+        onClearCache={vi.fn()}
+        onSetupWebhook={vi.fn()}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Generate Batch Messages/i }))
+    expect(onGenerateBatch).toHaveBeenCalled()
+  })
+})

--- a/client/src/components/ToolsDrawer.tsx
+++ b/client/src/components/ToolsDrawer.tsx
@@ -1,0 +1,116 @@
+// See CHANGELOG.md for 2025-06-17 [Added]
+import React, { useEffect, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { RefreshCw, Link2 } from 'lucide-react'
+import type { MessageThread } from '@shared/schema'
+
+type ToolsDrawerProps = {
+  open: boolean
+  onClose: () => void
+  onGenerateBatch: () => void
+  threads: MessageThread[]
+  customThreadId: string
+  setCustomThreadId: (id: string) => void
+  customMessage: string
+  setCustomMessage: (msg: string) => void
+  onSendCustom: () => void
+  canSend?: boolean
+  onReloadDb: () => void
+  onClearCache: () => void
+  onSetupWebhook: () => void
+}
+
+const ToolsDrawer = ({
+  open,
+  onClose,
+  onGenerateBatch,
+  threads,
+  customThreadId,
+  setCustomThreadId,
+  customMessage,
+  setCustomMessage,
+  onSendCustom,
+  canSend = true,
+  onReloadDb,
+  onClearCache,
+  onSetupWebhook,
+}: ToolsDrawerProps) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus()
+      const handleKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') onClose()
+      }
+      document.addEventListener('keydown', handleKey)
+      return () => document.removeEventListener('keydown', handleKey)
+    }
+  }, [open, onClose])
+
+  useEffect(() => {
+    const trap = (e: FocusEvent) => {
+      if (open && inputRef.current && !inputRef.current.closest('.tools-drawer')?.contains(e.target as Node)) {
+        e.stopPropagation()
+        inputRef.current?.focus()
+      }
+    }
+    if (open) {
+      document.addEventListener('focusin', trap)
+      return () => document.removeEventListener('focusin', trap)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div className="tools-drawer fixed top-0 right-0 z-50 w-2/5 max-w-sm min-w-[240px] h-full bg-white shadow-2xl rounded-l-lg py-4 px-4 flex flex-col space-y-2">
+        <div className="text-xs text-gray-500 font-semibold uppercase mb-1 mt-2 px-1">Tools</div>
+        <Button className="w-full mb-2 bg-gray-900 text-white hover:bg-gray-800 border-gray-900" onClick={() => { onGenerateBatch(); onClose() }}>
+          Generate Batch Messages
+        </Button>
+        <Select onValueChange={setCustomThreadId} value={customThreadId}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Generate For Thread" />
+          </SelectTrigger>
+          <SelectContent className="max-h-60 overflow-y-auto">
+            {threads.map((thread) => (
+              <SelectItem key={thread.id} value={String(thread.id)}>
+                {thread.participantName}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          ref={inputRef}
+          className="mt-2"
+          placeholder="Custom message"
+          value={customMessage}
+          onChange={(e) => setCustomMessage(e.target.value)}
+        />
+        <Button className="w-full mt-2" disabled={!canSend} onClick={() => { onSendCustom(); onClose() }}>
+          Send Custom Message
+        </Button>
+        <Button variant="outline" className="w-full mt-2" onClick={() => { onReloadDb(); onClose() }}>
+          <RefreshCw className="h-4 w-4 mr-2" />
+          Reload - database
+        </Button>
+        <Button variant="outline" className="w-full mt-2" onClick={() => { onClearCache(); onClose() }}>
+          <RefreshCw className="h-4 w-4 mr-2" />
+          Reload - frontend cache
+        </Button>
+        <Button variant="outline" className="w-full mt-2" onClick={() => { onSetupWebhook(); onClose() }}>
+          <Link2 className="h-4 w-4 mr-2" />
+          Setup Webhook
+        </Button>
+      </div>
+    </>
+  )
+}
+
+export default ToolsDrawer
+

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -36,23 +36,18 @@ import {
   Loader2,
   SearchX,
   ChevronDown,
-  FileQuestion,
   RefreshCw,
   Link2,
+  Wrench,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
+import ToolsDrawer from "@/components/ToolsDrawer";
 import { Input } from "@/components/ui/input";
 import ChatHeader from "@/components/layout/ChatHeader";
 
 // Removed mobile headers so tools remain desktop-only
 
-import { ThreadType, Settings } from "@shared/schema";
+import { ThreadType, Settings, MessageThread } from "@shared/schema";
 
 const ThreadedMessages: React.FC = () => {
   const [activeThreadId, setActiveThreadId] = useState<number | null>(null);
@@ -66,6 +61,7 @@ const ThreadedMessages: React.FC = () => {
   const queryClient = useQueryClient();
   const [customThreadId, setCustomThreadId] = useState("");
   const [customMessage, setCustomMessage] = useState("");
+  const [toolsOpen, setToolsOpen] = useState(false);
   const [activeThreadData, setActiveThreadData] = useState<ThreadType | null>(
     null,
   );
@@ -349,238 +345,111 @@ const ThreadedMessages: React.FC = () => {
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-2xl font-bold">Messages</h1>
           <div className="flex items-center space-x-2">
-            <div className="relative">
-              <Accordion type="single" collapsible>
-                <AccordionItem value="tools">
-                  <AccordionTrigger className="bg-gray-900 text-white px-4 py-2 rounded flex items-center h-9 border-gray-900 hover:bg-gray-800">
-                    <FileQuestion className="h-4 w-4 mr-2" />
-                    Tools
-                  </AccordionTrigger>
-                  <AccordionContent className="absolute right-0 z-10 mt-1 bg-white border border-gray-200 shadow-lg rounded w-64">
-                    <div className="px-4 py-3">
-                      <Button
-                        className="w-full mb-2 bg-gray-900 text-white hover:bg-gray-800 border-gray-900"
-                        onClick={() => {
-                          fetch("/api/test/generate-batch", { method: "POST" })
-                            .then((res) => {
-                              if (!res.ok) {
-                                return res.text().then((t) => {
-                                  throw new Error(`Server error: ${t}`);
-                                });
-                              }
-                              return res.json();
-                            })
-                            .then(() => {
-                              queryClient.invalidateQueries({
-                                queryKey: ["/api/instagram/messages"],
-                              });
-                              queryClient.invalidateQueries({
-                                queryKey: ["/api/youtube/messages"],
-                              });
-                              toast({
-                                title: "Batch generated",
-                                description: "10 messages created",
-                              });
-                            })
-                            .catch((err) => {
-                              console.error("Batch error:", err);
-                              toast({
-                                title: "Error",
-                                description: String(err),
-                                variant: "destructive",
-                              });
-                            });
-                        }}
-                      >
-                        Generate Batch Messages
-                      </Button>
-                      <Select
-                        onValueChange={(id) => setCustomThreadId(id)}
-                        value={customThreadId}
-                      >
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Generate For Thread" />
-                        </SelectTrigger>
-                        <SelectContent className="max-h-60 overflow-y-auto">
-                          {Array.isArray(threads) &&
-                            (threads as any[]).map((thread: any) => (
-                              <SelectItem
-                                key={thread.id}
-                                value={String(thread.id)}
-                              >
-                                {thread.participantName}
-                              </SelectItem>
-                            ))}
-                        </SelectContent>
-                      </Select>
-                      <Input
-                        className="mt-2"
-                        placeholder="Custom message"
-                        value={customMessage}
-                        onChange={(e) => setCustomMessage(e.target.value)}
-                      />
-                      <Button
-                        className="w-full mt-2"
-                        onClick={() => {
-                          if (!customThreadId) return;
-                          fetch(
-                            `/api/test/generate-for-user/${customThreadId}`,
-                            {
-                              method: "POST",
-                              headers: { "Content-Type": "application/json" },
-                              body: JSON.stringify({ content: customMessage }),
-                            },
-                          )
-                            .then((res) => {
-                              if (!res.ok) {
-                                return res.text().then((t) => {
-                                  throw new Error(`Server error: ${t}`);
-                                });
-                              }
-                              return res.json();
-                            })
-                            .then((newMsg) => {
-                              queryClient.invalidateQueries({
-                                queryKey: ["/api/threads"],
-                              });
-                              toast({
-                                title: "Message generated",
-                                description: `Message added to thread ${customThreadId}`,
-                              });
-                              setCustomMessage("");
-
-                              const thread = Array.isArray(threads)
-                                ? (threads as any[]).find((t) => t.id === Number(customThreadId))
-                                : null;
-                              const channelAutoReply = thread?.source === 'instagram'
-                                ? settings?.aiSettings?.autoReplyInstagram
-                                : thread?.source === 'youtube'
-                                ? settings?.aiSettings?.autoReplyYoutube
-                                : false;
-
-                              if (thread?.autoReply && channelAutoReply) {
-                                console.log('Triggering auto-reply for custom message', newMsg.id);
-                                const endpoint = thread.source === 'instagram'
-                                  ? '/api/instagram/ai-reply'
-                                  : '/api/youtube/ai-reply';
-
-                                fetch(endpoint, {
-                                  method: 'POST',
-                                  headers: { 'Content-Type': 'application/json' },
-                                  body: JSON.stringify({ messageId: newMsg.id })
-                                })
-                                  .then(() => {
-                                    console.log('Auto-reply triggered after custom message');
-                                  })
-                                  .catch((err) => {
-                                    console.error('Auto-reply error:', err);
-                                  });
-                              }
-                            })
-                            .catch((err) => {
-                              console.error("Generate error:", err);
-                              toast({
-                                title: "Error",
-                                description: String(err),
-                                variant: "destructive",
-                              });
-                            });
-                        }}
-                      >
-                        Send Custom Message
-                      </Button>
-                      {/* Database refresh replicates Testing Tools page */}
-                      <Button
-                        className="w-full mt-2"
-                        variant="outline"
-                        onClick={() => {
-                          toast({
-                            title: "Database Refresh",
-                            description: "Refreshing messages from database...",
-                          });
-                          // Refetch messages directly from storage
-                          queryClient.invalidateQueries({
-                            queryKey: ["/api/instagram/messages"],
-                          });
-                          queryClient.invalidateQueries({
-                            queryKey: ["/api/youtube/messages"],
-                          });
-                        }}
-                      >
-                        <RefreshCw className="h-4 w-4 mr-2" />
-                        Reload - database
-                      </Button>
-                      {/* Clear frontend cache for fresh data */}
-                      <Button
-                        className="w-full mt-2"
-                        variant="outline"
-                        onClick={() => {
-                          toast({
-                            title: "Cache Refresh",
-                            description:
-                              "Clearing frontend cache and refreshing data...",
-                          });
-                          // Invalidate all cached queries
-                          queryClient.invalidateQueries();
-                        }}
-                      >
-                        <RefreshCw className="h-4 w-4 mr-2" />
-                        Reload - frontend cache
-                      </Button>
-                      {/* Setup Instagram webhook for real-time updates */}
-                      <Button
-                        className="w-full mt-2"
-                        variant="outline"
-                        onClick={() => {
-                          const setupWebhook = async () => {
-                            try {
-                              const response = await fetch(
-                                "/api/instagram/setup-webhook",
-                                {
-                                  method: "POST",
-                                  headers: {
-                                    "Content-Type": "application/json",
-                                  },
-                                },
-                              );
-                              const data = await response.json();
-
-                              if (response.ok) {
-                                toast({
-                                  title: "Webhook Setup",
-                                  description:
-                                    "Instagram webhook successfully configured",
-                                });
-                              } else {
-                                toast({
-                                  title: "Webhook Setup Failed",
-                                  description:
-                                    data.message ||
-                                    "Failed to set up Instagram webhook",
-                                  variant: "destructive",
-                                });
-                              }
-                            } catch (error) {
-                              toast({
-                                title: "Webhook Setup Error",
-                                description:
-                                  "An error occurred during webhook setup",
-                                variant: "destructive",
-                              });
-                            }
-                          };
-                          setupWebhook();
-                        }}
-                      >
-                        <Link2 className="h-4 w-4 mr-2" />
-                        Setup Webhook
-                      </Button>
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
+            <div className="hidden md:block">
+              <Button variant="outline" size="sm" onClick={() => setToolsOpen(true)} className="flex items-center bg-gray-50 hover:bg-gray-100 text-black border border-gray-300">
+                <Wrench className="w-4 h-4 mr-2" />
+                Tools
+              </Button>
             </div>
           </div>
+          <ToolsDrawer
+            open={toolsOpen}
+            onClose={() => setToolsOpen(false)}
+            onGenerateBatch={() => {
+              fetch('/api/test/generate-batch', { method: 'POST' })
+                .then((res) => {
+                  if (!res.ok) {
+                    return res.text().then((t) => { throw new Error(`Server error: ${t}`) })
+                  }
+                  return res.json()
+                })
+                .then(() => {
+                  queryClient.invalidateQueries({ queryKey: ['/api/instagram/messages'] })
+                  queryClient.invalidateQueries({ queryKey: ['/api/youtube/messages'] })
+                  toast({ title: 'Batch generated', description: '10 messages created' })
+                })
+                .catch((err) => {
+                  console.error('Batch error:', err)
+                  toast({ title: 'Error', description: String(err), variant: 'destructive' })
+                })
+            }}
+            threads={Array.isArray(threads) ? (threads as MessageThread[]) : []}
+            customThreadId={customThreadId}
+            setCustomThreadId={setCustomThreadId}
+            customMessage={customMessage}
+            setCustomMessage={setCustomMessage}
+            onSendCustom={() => {
+              if (!customThreadId) return
+              fetch(`/api/test/generate-for-user/${customThreadId}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: customMessage }),
+              })
+                .then((res) => {
+                  if (!res.ok) {
+                    return res.text().then((t) => {
+                      throw new Error(`Server error: ${t}`)
+                    })
+                  }
+                  return res.json()
+                })
+                .then((newMsg) => {
+                  queryClient.invalidateQueries({ queryKey: ['/api/threads'] })
+                  toast({ title: 'Message generated', description: `Message added to thread ${customThreadId}` })
+                  setCustomMessage('')
+
+                  const thread = Array.isArray(threads) ? (threads as any[]).find((t) => t.id === Number(customThreadId)) : null
+                  const channelAutoReply = thread?.source === 'instagram'
+                    ? settings?.aiSettings?.autoReplyInstagram
+                    : thread?.source === 'youtube'
+                      ? settings?.aiSettings?.autoReplyYoutube
+                      : false
+
+                  if (thread?.autoReply && channelAutoReply) {
+                    const endpoint = thread.source === 'instagram' ? '/api/instagram/ai-reply' : '/api/youtube/ai-reply'
+                    fetch(endpoint, {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ messageId: newMsg.id })
+                    }).catch((err) => console.error('Auto-reply error:', err))
+                  }
+                })
+                .catch((err) => {
+                  console.error('Generate error:', err)
+                  toast({ title: 'Error', description: String(err), variant: 'destructive' })
+                })
+            }}
+            canSend={true}
+            onReloadDb={() => {
+              toast({ title: 'Database Refresh', description: 'Refreshing messages from database...' })
+              queryClient.invalidateQueries({ queryKey: ['/api/instagram/messages'] })
+              queryClient.invalidateQueries({ queryKey: ['/api/youtube/messages'] })
+            }}
+            onClearCache={() => {
+              toast({ title: 'Cache Refresh', description: 'Clearing frontend cache and refreshing data...' })
+              queryClient.invalidateQueries()
+            }}
+            onSetupWebhook={() => {
+              const setupWebhook = async () => {
+                try {
+                  const response = await fetch('/api/instagram/setup-webhook', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                  })
+                  const data = await response.json()
+
+                  if (response.ok) {
+                    toast({ title: 'Webhook Setup', description: 'Instagram webhook successfully configured' })
+                  } else {
+                    toast({ title: 'Webhook Setup Failed', description: data.message || 'Failed to set up Instagram webhook', variant: 'destructive' })
+                  }
+                } catch (error) {
+                  toast({ title: 'Webhook Setup Error', description: 'An error occurred during webhook setup', variant: 'destructive' })
+                }
+              }
+              setupWebhook()
+            }}
+          />
         </div>
         {/* Desktop tabs */}
         <div className="hidden md:block">

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    environment: 'node',
+    environment: 'jsdom',
     include: ['**/*.test.ts', '**/*.test.tsx'],
     env: {
       DATABASE_URL: 'postgres://test'


### PR DESCRIPTION
## Summary
- replace desktop Tools dropdown with new ToolsDrawer component
- update Messages and ThreadedMessages pages to launch the drawer
- document Tools drawer in README
- log changes in CHANGELOG
- configure Vitest for jsdom and add basic ToolsDrawer tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: AIService generateEmbedding returns zeros on failure)*

------
https://chatgpt.com/codex/tasks/task_e_684caa93787483339772eb831cbe0ef6