### PR TITLE
Add AvatarPersonaConfig interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,7 +199,9 @@ CHANGLOG.md file.
   disabled when empty.
 - [Codex][Changed] Adjust AI Replies row layout in `ThreadRow` for a tighter
   grouping.
-- [Codex][Fixed-2] Batch messages now create threads and refresh the thread list.
+- [Codex][Fixed-2] Batch messages now create threads and refresh the thread
+  list.
 - [Codex][Added] Configurable response delay for automated AI replies.
 
-
+2025-06-18 [Codex][Added] AvatarPersonaConfig interface for persona setup
+described in docs/stage_1_persona.md.

--- a/client/src/types/AvatarPersonaConfig.ts
+++ b/client/src/types/AvatarPersonaConfig.ts
@@ -1,0 +1,26 @@
+// See CHANGELOG.md for 2025-06-18 [Added]
+/**
+ * Configuration describing an avatar's persona.
+ */
+export interface AvatarPersonaConfig {
+  /**
+   * Freeform text describing the avatar's tone and overall speaking style.
+   */
+  toneDescription: string
+  /**
+   * Additional style keywords to reinforce the desired voice.
+   */
+  styleTags: string[]
+  /**
+   * Topics that the avatar is allowed to discuss.
+   */
+  allowedTopics: string[]
+  /**
+   * Topics that must not be discussed by the avatar.
+   */
+  restrictedTopics: string[]
+  /**
+   * Default response when a user asks about a restricted topic.
+   */
+  fallbackReply: string
+}


### PR DESCRIPTION
## Summary
- create `AvatarPersonaConfig` interface for persona feature
- document persona configuration fields with JSDoc

## Testing
- `npm run type-check`
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684e53dbac3c8333b0b2fc56197a0e20