### PR TITLE
Add persona settings page with system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,7 +199,10 @@ CHANGLOG.md file.
   disabled when empty.
 - [Codex][Changed] Adjust AI Replies row layout in `ThreadRow` for a tighter
   grouping.
-- [Codex][Fixed-2] Batch messages now create threads and refresh the thread list.
+- [Codex][Fixed-2] Batch messages now create threads and refresh the thread
+  list.
 - [Codex][Added] Configurable response delay for automated AI replies.
 
+## 2025-06-15
 
+[Codex][Added] Persona settings page and system prompt storage.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,22 +1,23 @@
 // See CHANGELOG.md for 2025-06-12 [Changed - remove MobileHeader]
-import { Switch, Route, Redirect } from "wouter";
-import { queryClient } from "./lib/queryClient";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { Toaster } from "@/components/ui/toaster";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import { ThemeProvider } from "@/components/ui/theme-provider";
+import { Switch, Route, Redirect } from 'wouter'
+import { queryClient } from './lib/queryClient'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { Toaster } from '@/components/ui/toaster'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { ThemeProvider } from '@/components/ui/theme-provider'
 
-import NotFound from "@/pages/not-found";
-import Instagram from "@/pages/instagram/Instagram";
-import ThreadedMessages from "@/pages/messages/ThreadedMessages";
-import ConnectInstagram from "@/pages/connect/ConnectInstagram";
-import Settings from "@/pages/settings/Settings";
-import Analytics from "@/pages/analytics/Analytics";
-import Automation from "@/pages/automation/Automation";
-import Testing from "@/pages/testing/Testing";
-import Privacy from "@/pages/privacy/Privacy";
+import NotFound from '@/pages/not-found'
+import Instagram from '@/pages/instagram/Instagram'
+import ThreadedMessages from '@/pages/messages/ThreadedMessages'
+import ConnectInstagram from '@/pages/connect/ConnectInstagram'
+import Settings from '@/pages/settings/Settings'
+import AvatarSettingsPage from '@/pages/settings/AvatarSettingsPage'
+import Analytics from '@/pages/analytics/Analytics'
+import Automation from '@/pages/automation/Automation'
+import Testing from '@/pages/testing/Testing'
+import Privacy from '@/pages/privacy/Privacy'
 
-import Sidebar from "@/components/layout/Sidebar";
+import Sidebar from '@/components/layout/Sidebar'
 
 function Router() {
   return (
@@ -31,6 +32,7 @@ function Router() {
           </Route>
           <Route path="/connect/instagram" component={ConnectInstagram} />
           <Route path="/settings" component={Settings} />
+          <Route path="/settings/persona" component={AvatarSettingsPage} />
           <Route path="/analytics" component={Analytics} />
           <Route path="/automation" component={Automation} />
           <Route path="/testing" component={Testing} />
@@ -39,7 +41,7 @@ function Router() {
         </Switch>
       </div>
     </div>
-  );
+  )
 }
 
 function App() {
@@ -52,7 +54,7 @@ function App() {
         </TooltipProvider>
       </ThemeProvider>
     </QueryClientProvider>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/client/src/components/PrivacyPersonalityForm.test.tsx
+++ b/client/src/components/PrivacyPersonalityForm.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import PrivacyPersonalityForm from './PrivacyPersonalityForm'
+
+describe('PrivacyPersonalityForm', () => {
+  it('renders Save button', () => {
+    const html = renderToStaticMarkup(
+      <PrivacyPersonalityForm onSave={() => {}} />,
+    )
+    expect(html).toContain('Save Preferences')
+  })
+})

--- a/client/src/components/PrivacyPersonalityForm.tsx
+++ b/client/src/components/PrivacyPersonalityForm.tsx
@@ -1,0 +1,139 @@
+// See docs/stage_1_persona.md - collects persona config
+import React, { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { AvatarPersonaConfig } from '@/types/AvatarPersonaConfig'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+
+interface Props {
+  defaultValues?: AvatarPersonaConfig
+  onSave: (config: AvatarPersonaConfig) => void
+}
+
+const emptyConfig: AvatarPersonaConfig = {
+  toneDescription: '',
+  styleTags: [],
+  allowedTopics: [],
+  restrictedTopics: [],
+  fallbackReply: '',
+}
+
+export default function PrivacyPersonalityForm({
+  defaultValues,
+  onSave,
+}: Props) {
+  const form = useForm<AvatarPersonaConfig>({
+    defaultValues: defaultValues ?? emptyConfig,
+  })
+  const [saving, setSaving] = useState(false)
+
+  const submit = form.handleSubmit((values) => {
+    setSaving(true)
+    // comma separated fields -> arrays
+    const config: AvatarPersonaConfig = {
+      ...values,
+      styleTags: values.styleTags
+        .toString()
+        .split(/\s*,\s*/)
+        .filter(Boolean),
+      allowedTopics: values.allowedTopics
+        .toString()
+        .split(/\s*,\s*/)
+        .filter(Boolean),
+      restrictedTopics: values.restrictedTopics
+        .toString()
+        .split(/\s*,\s*/)
+        .filter(Boolean),
+    }
+    onSave(config)
+    setSaving(false)
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={submit} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="toneDescription"
+          rules={{ required: true }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Tone &amp; Style</FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  placeholder="Describe how your avatar should speak"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="styleTags"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Style Tags (comma separated)</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="Friendly, Sarcastic" />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="allowedTopics"
+          rules={{ required: true }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Allowed Topics (comma separated)</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="Pets, hobbies" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="restrictedTopics"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Restricted Topics (comma separated)</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="Home address" />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="fallbackReply"
+          rules={{ required: true }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Fallback Reply</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="Sorry, I keep that private" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={saving}>
+          Save Preferences
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -1,51 +1,56 @@
 // See CHANGELOG.md for 2025-06-09 [Added]
 // See CHANGELOG.md for 2025-06-10 [Added]
-import { Link, useLocation } from "wouter";
-import { cn } from "@/lib/utils";
-import { 
-  Mail, 
-  MessageSquare, 
-  Settings, 
-  BarChart2, 
+import { Link, useLocation } from 'wouter'
+import { cn } from '@/lib/utils'
+import {
+  Mail,
+  MessageSquare,
+  Settings,
+  BarChart2,
   Calendar,
   Code,
   Lock,
-} from "lucide-react";
+  Brain,
+} from 'lucide-react'
 
 type SidebarProps = {
-  className?: string;
-};
+  className?: string
+}
 
 type NavItemProps = {
-  href: string;
-  icon: React.ReactNode;
-  children: React.ReactNode;
-  active?: boolean;
-};
+  href: string
+  icon: React.ReactNode
+  children: React.ReactNode
+  active?: boolean
+}
 
 const NavItem = ({ href, icon, children, active }: NavItemProps) => {
   return (
     <Link href={href}>
-      <a className={cn(
-        "flex items-center px-2 py-2 text-sm font-medium rounded-md",
-        active
-          ? "bg-blue-600 text-white"
-          : "text-neutral-700 hover:bg-neutral-100"
-      )}>
-        <span className={cn(
-          "h-5 w-5 mr-3",
-          active ? "text-white" : "text-neutral-500"
-        )}>
+      <a
+        className={cn(
+          'flex items-center px-2 py-2 text-sm font-medium rounded-md',
+          active
+            ? 'bg-blue-600 text-white'
+            : 'text-neutral-700 hover:bg-neutral-100',
+        )}
+      >
+        <span
+          className={cn(
+            'h-5 w-5 mr-3',
+            active ? 'text-white' : 'text-neutral-500',
+          )}
+        >
           {icon}
         </span>
         {children}
       </a>
     </Link>
-  );
-};
+  )
+}
 
 const Sidebar = ({ className }: SidebarProps) => {
-  const [location] = useLocation();
+  const [location] = useLocation()
 
   return (
     <div className="hidden md:flex md:flex-shrink-0">
@@ -53,42 +58,55 @@ const Sidebar = ({ className }: SidebarProps) => {
         <div className="h-0 flex-1 flex flex-col">
           <div className="flex items-center h-16 flex-shrink-0 px-4 bg-white border-b border-neutral-200">
             <h1 className="text-lg font-semibold text-neutral-900">Avatar</h1>
-            <span className="ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-primary-100 text-primary-700">Beta</span>
+            <span className="ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-primary-100 text-primary-700">
+              Beta
+            </span>
           </div>
           <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto bg-white">
             <nav className="mt-5 flex-1 px-2 space-y-1">
-              <NavItem 
-                href="/instagram" 
-                icon={<MessageSquare />} 
-                active={location === "/" || location === "/instagram" || location === "/youtube"}
+              <NavItem
+                href="/instagram"
+                icon={<MessageSquare />}
+                active={
+                  location === '/' ||
+                  location === '/instagram' ||
+                  location === '/youtube'
+                }
               >
                 Messages
               </NavItem>
-              <NavItem 
-                href="/connect/instagram" 
-                icon={<Mail />} 
-                active={location === "/connect/instagram"}
+              <NavItem
+                href="/connect/instagram"
+                icon={<Mail />}
+                active={location === '/connect/instagram'}
               >
                 Connect Instagram
               </NavItem>
-              <NavItem 
-                href="/settings" 
-                icon={<Settings />} 
-                active={location === "/settings"}
+              <NavItem
+                href="/settings"
+                icon={<Settings />}
+                active={location === '/settings'}
               >
                 Settings
               </NavItem>
-              <NavItem 
-                href="/analytics" 
-                icon={<BarChart2 />} 
-                active={location === "/analytics"}
+              <NavItem
+                href="/settings/persona"
+                icon={<Brain />}
+                active={location === '/settings/persona'}
+              >
+                Persona
+              </NavItem>
+              <NavItem
+                href="/analytics"
+                icon={<BarChart2 />}
+                active={location === '/analytics'}
               >
                 Analytics
               </NavItem>
-              <NavItem 
-                href="/automation" 
-                icon={<Calendar />} 
-                active={location === "/automation"}
+              <NavItem
+                href="/automation"
+                icon={<Calendar />}
+                active={location === '/automation'}
               >
                 Automation Rules
               </NavItem>
@@ -96,40 +114,42 @@ const Sidebar = ({ className }: SidebarProps) => {
               <NavItem
                 href="/testing"
                 icon={<Code />}
-                active={location === "/testing"}
+                active={location === '/testing'}
               >
                 Testing Tools
               </NavItem>
               <NavItem
                 href="/privacy"
                 icon={<Lock />}
-                active={location === "/privacy"}
+                active={location === '/privacy'}
               >
                 Privacy Policy
               </NavItem>
-
-
             </nav>
           </div>
           <div className="p-4 border-t border-neutral-200 bg-white">
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <img 
-                  className="h-8 w-8 rounded-full" 
-                  src="https://avatars.githubusercontent.com/u/1" 
-                  alt="User profile" 
+                <img
+                  className="h-8 w-8 rounded-full"
+                  src="https://avatars.githubusercontent.com/u/1"
+                  alt="User profile"
                 />
               </div>
               <div className="ml-3">
-                <p className="text-sm font-medium text-neutral-700 truncate">Sarah Connor</p>
-                <p className="text-xs font-medium text-neutral-500 truncate">sarah@example.com</p>
+                <p className="text-sm font-medium text-neutral-700 truncate">
+                  Sarah Connor
+                </p>
+                <p className="text-xs font-medium text-neutral-500 truncate">
+                  sarah@example.com
+                </p>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default Sidebar;
+export default Sidebar

--- a/client/src/lib/prompt.ts
+++ b/client/src/lib/prompt.ts
@@ -1,0 +1,12 @@
+// Added for persona config feature - see CHANGELOG.md entry
+import { AvatarPersonaConfig } from '@/types/AvatarPersonaConfig'
+
+/** Build a system prompt string from persona configuration. */
+export function buildSystemPrompt(config: AvatarPersonaConfig): string {
+  const tone = config.toneDescription.trim()
+  const allowed = config.allowedTopics.join(', ')
+  const restricted = config.restrictedTopics.join(', ')
+  const tags = config.styleTags.join(', ')
+  const fallback = config.fallbackReply.trim()
+  return `You are the creator's digital twin.\nTone: "${tone}"\nTags: ${tags}\nAllowed topics: ${allowed}\nForbidden topics: ${restricted}\nIf asked about a forbidden topic reply: "${fallback}"\nSpeak in the first person as if you are the creator and never reveal you are an AI.`
+}

--- a/client/src/pages/settings/AvatarSettingsPage.tsx
+++ b/client/src/pages/settings/AvatarSettingsPage.tsx
@@ -1,0 +1,27 @@
+// Renders persona form and shows prompt preview - see docs/stage_1_persona.md
+import { useState } from 'react'
+import PrivacyPersonalityForm from '@/components/PrivacyPersonalityForm'
+import { AvatarPersonaConfig } from '@/types/AvatarPersonaConfig'
+import { buildSystemPrompt } from '@/lib/prompt'
+
+export default function AvatarSettingsPage() {
+  const [prompt, setPrompt] = useState('')
+
+  return (
+    <div className="p-6 space-y-6">
+      <h2 className="text-2xl font-bold">Persona: Voice &amp; Boundaries</h2>
+      <PrivacyPersonalityForm
+        onSave={(cfg: AvatarPersonaConfig) => {
+          const built = buildSystemPrompt(cfg)
+          setPrompt(built)
+        }}
+      />
+      {prompt && (
+        <details className="border p-4 rounded-md">
+          <summary className="cursor-pointer">Generated Prompt</summary>
+          <pre className="whitespace-pre-wrap mt-2 text-sm">{prompt}</pre>
+        </details>
+      )}
+    </div>
+  )
+}

--- a/client/src/types/AvatarPersonaConfig.ts
+++ b/client/src/types/AvatarPersonaConfig.ts
@@ -1,0 +1,16 @@
+// Added for persona config feature - see CHANGELOG.md entry
+/**
+ * Configuration describing the creator's desired avatar persona.
+ */
+export interface AvatarPersonaConfig {
+  /** A free form description of tone and communication style */
+  toneDescription: string
+  /** Short style tags like "Friendly", "Sarcastic" */
+  styleTags: string[]
+  /** Topics the avatar may discuss */
+  allowedTopics: string[]
+  /** Topics the avatar must avoid */
+  restrictedTopics: string[]
+  /** Default reply when a restricted topic is asked */
+  fallbackReply: string
+}

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -1,15 +1,14 @@
-
 // See CHANGELOG.md for 2025-06-11 [Added]
 // See CHANGELOG.md for 2025-06-13 [Added]
 // See CHANGELOG.md for 2025-06-14 [Added]
 // See CHANGELOG.md for 2025-06-12 [Fixed]
 // See CHANGELOG.md for 2025-06-13 [Added-2]
-import { 
-  messages, 
-  users, 
-  settings, 
-  automationRules, 
-  leads, 
+import {
+  messages,
+  users,
+  settings,
+  automationRules,
+  leads,
   analytics,
   messageThreads,
   contentItems,
@@ -31,55 +30,66 @@ import {
   type InsertMessageThread,
   type ThreadType,
   type InsertContentItem,
-  type ContentItem
-} from "@shared/schema";
-import { db } from "./db";
-import { eq, desc, and, inArray, sql } from "drizzle-orm";
-import { IStorage } from "./storage";
-import { log } from "./logger";
+  type ContentItem,
+} from '@shared/schema'
+import { db } from './db'
+import { eq, desc, and, inArray, sql } from 'drizzle-orm'
+import { IStorage } from './storage'
+import { log } from './logger'
 
 export class DatabaseStorage implements IStorage {
   // Thread methods for conversation continuity
   async getThread(id: number): Promise<MessageThread | undefined> {
-    const [thread] = await db.select().from(messageThreads).where(eq(messageThreads.id, id));
-    return thread;
+    const [thread] = await db
+      .select()
+      .from(messageThreads)
+      .where(eq(messageThreads.id, id))
+    return thread
   }
 
   async getThreads(userId: number, source?: string): Promise<ThreadType[]> {
     let query = db
       .select()
       .from(messageThreads)
-      .where(eq(messageThreads.userId, userId));
+      .where(eq(messageThreads.userId, userId))
 
     if (source) {
       query = db
         .select()
         .from(messageThreads)
         .where(
-          and(eq(messageThreads.userId, userId), eq(messageThreads.source, source))
-        );
+          and(
+            eq(messageThreads.userId, userId),
+            eq(messageThreads.source, source),
+          ),
+        )
     }
 
     // Order by most recent message
-    const threads = await query.orderBy(desc(messageThreads.lastMessageAt));
+    const threads = await query.orderBy(desc(messageThreads.lastMessageAt))
 
-    if (threads.length === 0) return [];
+    if (threads.length === 0) return []
 
     const intentRows = await db
       .select({
         threadId: messages.threadId,
-        highIntent: sql<boolean>`bool_or(${messages.isHighIntent})`
+        highIntent: sql<boolean>`bool_or(${messages.isHighIntent})`,
       })
       .from(messages)
-      .where(inArray(messages.threadId, threads.map(t => t.id)))
-      .groupBy(messages.threadId);
+      .where(
+        inArray(
+          messages.threadId,
+          threads.map((t) => t.id),
+        ),
+      )
+      .groupBy(messages.threadId)
 
     const intentMap = new Map<number, boolean>(
-      intentRows.map(r => [r.threadId!, Boolean(r.highIntent)])
-    );
+      intentRows.map((r) => [r.threadId!, Boolean(r.highIntent)]),
+    )
 
     // Map to ThreadType
-    return threads.map(thread => ({
+    return threads.map((thread) => ({
       id: thread.id,
       externalParticipantId: thread.externalParticipantId,
       participantName: thread.participantName,
@@ -90,93 +100,96 @@ export class DatabaseStorage implements IStorage {
       status: thread.status as 'active' | 'archived' | 'snoozed',
       unreadCount: thread.unreadCount || 0,
       autoReply: thread.autoReply ?? false,
-      isHighIntent: intentMap.get(thread.id) ?? false
-    }));
+      isHighIntent: intentMap.get(thread.id) ?? false,
+    }))
   }
-  
+
   async getThreadMessages(threadId: number): Promise<MessageType[]> {
-    log(`Fetching thread messages for thread ID ${threadId}`);
-    
+    log(`Fetching thread messages for thread ID ${threadId}`)
+
     // Get ALL messages for the thread, including threaded conversations
     const threadMessages = await db
       .select()
       .from(messages)
       .where(eq(messages.threadId, threadId))
-      .orderBy(messages.timestamp);
-    
-    log(`Found ${threadMessages.length} messages for thread ID ${threadId}`);
-    
+      .orderBy(messages.timestamp)
+
+    log(`Found ${threadMessages.length} messages for thread ID ${threadId}`)
+
     // Log message details for debugging
-    const messageDetails = threadMessages.map(m => ({
+    const messageDetails = threadMessages.map((m) => ({
       id: m.id,
       content: (m.content || '').substring(0, 30),
-      parentId: m.parentMessageId, 
+      parentId: m.parentMessageId,
       threadId: m.threadId,
-      timestamp: m.timestamp
-    }));
-    
-    log(`Thread messages with details: ${JSON.stringify(messageDetails)}`);
-    
+      timestamp: m.timestamp,
+    }))
+
+    log(`Thread messages with details: ${JSON.stringify(messageDetails)}`)
+
     // Build parent-child relationships for debugging
-    const parentChildMap = new Map();
-    threadMessages.forEach(msg => {
+    const parentChildMap = new Map()
+    threadMessages.forEach((msg) => {
       if (msg.parentMessageId) {
         if (!parentChildMap.has(msg.parentMessageId)) {
-          parentChildMap.set(msg.parentMessageId, []);
+          parentChildMap.set(msg.parentMessageId, [])
         }
-        parentChildMap.get(msg.parentMessageId).push(msg.id);
+        parentChildMap.get(msg.parentMessageId).push(msg.id)
       }
-    });
-    
+    })
+
     // Convert to a regular object for console logging
-    const parentChildObj: Record<number, number[]> = {};
+    const parentChildObj: Record<number, number[]> = {}
     parentChildMap.forEach((children, parentId) => {
-      parentChildObj[parentId] = children;
-    });
-    
-    log(`Parent-child relationships: ${JSON.stringify(parentChildObj)}`);
-    
+      parentChildObj[parentId] = children
+    })
+
+    log(`Parent-child relationships: ${JSON.stringify(parentChildObj)}`)
+
     // Map database messages to MessageType with proper parent-child relationships
-    const mappedMessages = threadMessages.map(msg => {
+    const mappedMessages = threadMessages.map((msg) => {
       // Ensure content is never undefined/null
       if (!msg.content) {
-        msg.content = `Message from ${msg.isOutbound ? 'You' : (msg.senderName || 'User')}`;
+        msg.content = `Message from ${msg.isOutbound ? 'You' : msg.senderName || 'User'}`
       }
-      
+
       // Map to MessageType with correct parent-child relationship
-      return this.mapMessageToMessageType(msg);
-    });
-    
-    return mappedMessages;
+      return this.mapMessageToMessageType(msg)
+    })
+
+    return mappedMessages
   }
-  
+
   async createThread(thread: InsertMessageThread): Promise<MessageThread> {
     const [newThread] = await db
       .insert(messageThreads)
       .values(thread)
-      .returning();
-    
-    return newThread;
+      .returning()
+
+    return newThread
   }
-  
-  async updateThread(id: number, updates: Partial<MessageThread>): Promise<MessageThread | undefined> {
+
+  async updateThread(
+    id: number,
+    updates: Partial<MessageThread>,
+  ): Promise<MessageThread | undefined> {
     const [updatedThread] = await db
       .update(messageThreads)
       .set({
-        ...updates
+        ...updates,
       })
       .where(eq(messageThreads.id, id))
-      .returning();
-    
-    return updatedThread;
+      .returning()
+
+    return updatedThread
   }
-  
+
   async findOrCreateThreadByParticipant(
-    userId: number, 
-    externalParticipantId: string, 
-    participantName: string, 
+    userId: number,
+    externalParticipantId: string,
+    participantName: string,
     source: string,
-    participantAvatar?: string
+    participantAvatar?: string,
   ): Promise<MessageThread> {
     // Try to find existing thread
     const [existingThread] = await db
@@ -186,14 +199,14 @@ export class DatabaseStorage implements IStorage {
         and(
           eq(messageThreads.userId, userId),
           eq(messageThreads.externalParticipantId, externalParticipantId),
-          eq(messageThreads.source, source)
-        )
-      );
-    
+          eq(messageThreads.source, source),
+        ),
+      )
+
     if (existingThread) {
-      return existingThread;
+      return existingThread
     }
-    
+
     // Create new thread if one doesn't exist
     const [newThread] = await db
       .insert(messageThreads)
@@ -206,43 +219,48 @@ export class DatabaseStorage implements IStorage {
         lastMessageAt: new Date(),
         status: 'active',
         unreadCount: 0,
-        metadata: {}
+        metadata: {},
       })
-      .returning();
-    
-    return newThread;
+      .returning()
+
+    return newThread
   }
-  
-  async addMessageToThread(threadId: number, message: InsertMessage): Promise<Message> {
+
+  async addMessageToThread(
+    threadId: number,
+    message: InsertMessage,
+  ): Promise<Message> {
     // First, get the thread to ensure it exists
-    const thread = await this.getThread(threadId);
+    const thread = await this.getThread(threadId)
     if (!thread) {
-      throw new Error(`Thread with ID ${threadId} not found`);
+      throw new Error(`Thread with ID ${threadId} not found`)
     }
-    
+
     // Ensure threadId is set in the message
     const messageWithThread = {
       ...message,
-      threadId
-    };
-    
+      threadId,
+    }
+
     // Create the message
     const [newMessage] = await db
       .insert(messages)
       .values(messageWithThread)
-      .returning();
-    
+      .returning()
+
     // Update thread's last message information
     await this.updateThread(threadId, {
       lastMessageAt: new Date(),
       lastMessageContent: message.content,
       // Increment unread count if it's an inbound message
-      unreadCount: message.isOutbound ? thread.unreadCount : (thread.unreadCount || 0) + 1
-    });
-    
-    return newMessage;
+      unreadCount: message.isOutbound
+        ? thread.unreadCount
+        : (thread.unreadCount || 0) + 1,
+    })
+
+    return newMessage
   }
-  
+
   async markThreadAsRead(threadId: number): Promise<boolean> {
     try {
       await db
@@ -250,116 +268,135 @@ export class DatabaseStorage implements IStorage {
         .set({
           unreadCount: 0,
         })
-        .where(eq(messageThreads.id, threadId));
+        .where(eq(messageThreads.id, threadId))
 
-      return true;
+      return true
     } catch (error) {
-      console.error("Error marking thread as read:", error);
-      return false;
+      console.error('Error marking thread as read:', error)
+      return false
     }
   }
 
   async deleteMessage(id: number): Promise<boolean> {
-    await db.delete(messages).where(eq(messages.id, id));
-    const [message] = await db.select().from(messages).where(eq(messages.id, id));
-    return message === undefined;
+    await db.delete(messages).where(eq(messages.id, id))
+    const [message] = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.id, id))
+    return message === undefined
   }
 
   async deleteThread(id: number): Promise<boolean> {
-    await db.delete(messages).where(eq(messages.threadId, id));
-    await db.delete(messageThreads).where(eq(messageThreads.id, id));
-    const [thread] = await db.select().from(messageThreads).where(eq(messageThreads.id, id));
-    return thread === undefined;
+    await db.delete(messages).where(eq(messages.threadId, id))
+    await db.delete(messageThreads).where(eq(messageThreads.id, id))
+    const [thread] = await db
+      .select()
+      .from(messageThreads)
+      .where(eq(messageThreads.id, id))
+    return thread === undefined
   }
 
   // Content methods for RAG pipeline
-  async createContentItem(contentItem: InsertContentItem): Promise<ContentItem> {
-    const [item] = await db
-      .insert(contentItems)
-      .values(contentItem)
-      .returning();
+  async createContentItem(
+    contentItem: InsertContentItem,
+  ): Promise<ContentItem> {
+    const [item] = await db.insert(contentItems).values(contentItem).returning()
 
-    return item;
+    return item
   }
 
-  async findSimilarContent(userId: number, embedding: number[], limit: number): Promise<string[]> {
+  async findSimilarContent(
+    userId: number,
+    embedding: number[],
+    limit: number,
+  ): Promise<string[]> {
     try {
-      const vector = `[${embedding.join(',')}]`;
+      const vector = `[${embedding.join(',')}]`
       const results = await db.execute(sql`
         SELECT content
         FROM content_items
         WHERE user_id = ${userId}
         ORDER BY embedding <-> ${sql.raw(vector)}
         LIMIT ${limit}
-      `);
-      return results.rows.map(r => r.content as string);
+      `)
+      return results.rows.map((r) => r.content as string)
     } catch (error) {
-      console.error('Error finding similar content:', error);
-      return [];
+      console.error('Error finding similar content:', error)
+      return []
     }
   }
-  
+
   // User methods
   async getUser(id: number): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.id, id));
-    return user;
+    const [user] = await db.select().from(users).where(eq(users.id, id))
+    return user
   }
 
   async getUserByUsername(username: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.username, username));
-    return user;
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.username, username))
+    return user
   }
 
   async createUser(insertUser: InsertUser): Promise<User> {
-    const [user] = await db.insert(users).values(insertUser).returning();
-    return user;
+    const [user] = await db.insert(users).values(insertUser).returning()
+    return user
   }
 
   // Message methods
   async getMessage(id: number): Promise<Message | undefined> {
-    const [message] = await db.select().from(messages).where(eq(messages.id, id));
-    return message;
+    const [message] = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.id, id))
+    return message
   }
 
   async getInstagramMessages(): Promise<MessageType[]> {
     const instagramMessages = await db
       .select()
       .from(messages)
-      .where(eq(messages.source, "instagram"))
-      .orderBy(desc(messages.timestamp));
-    
-    return instagramMessages.map(msg => this.mapMessageToMessageType(msg));
+      .where(eq(messages.source, 'instagram'))
+      .orderBy(desc(messages.timestamp))
+
+    return instagramMessages.map((msg) => this.mapMessageToMessageType(msg))
   }
 
   async getYoutubeMessages(): Promise<MessageType[]> {
     const youtubeMessages = await db
       .select()
       .from(messages)
-      .where(eq(messages.source, "youtube"))
-      .orderBy(desc(messages.timestamp));
-    
-    return youtubeMessages.map(msg => this.mapMessageToMessageType(msg));
+      .where(eq(messages.source, 'youtube'))
+      .orderBy(desc(messages.timestamp))
+
+    return youtubeMessages.map((msg) => this.mapMessageToMessageType(msg))
   }
 
   private mapMessageToMessageType(msg: Message): MessageType {
     const sender: SenderType = {
       id: msg.senderId,
       name: msg.senderName,
-      avatar: msg.senderAvatar || undefined
-    };
+      avatar: msg.senderAvatar || undefined,
+    }
 
     // Process the parentMessageId carefully to properly establish threads
     // Must be a number (not a string) for the React component to handle it correctly
-    let parentId = undefined;
-    
+    let parentId = undefined
+
     if (msg.parentMessageId !== undefined && msg.parentMessageId !== null) {
-      parentId = Number(msg.parentMessageId);
-      log(`Converting parentMessageId for message ${msg.id}: ${msg.parentMessageId} -> ${parentId}`);
-      
+      parentId = Number(msg.parentMessageId)
+      log(
+        `Converting parentMessageId for message ${msg.id}: ${msg.parentMessageId} -> ${parentId}`,
+      )
+
       // Check if it's a valid number after conversion
       if (isNaN(parentId)) {
-        parentId = undefined;
-        log(`Invalid parentMessageId for message ${msg.id}, setting to undefined`);
+        parentId = undefined
+        log(
+          `Invalid parentMessageId for message ${msg.id}, setting to undefined`,
+        )
       }
     }
 
@@ -373,33 +410,33 @@ export class DatabaseStorage implements IStorage {
       status: msg.status as 'new' | 'replied' | 'auto-replied',
       isHighIntent: msg.isHighIntent || false,
       reply: msg.reply || undefined,
-        threadId: msg.threadId ?? undefined,
+      threadId: msg.threadId ?? undefined,
       parentMessageId: parentId,
       isOutbound: msg.isOutbound || false,
       isAiGenerated: msg.isAiGenerated || false,
-      isAutoReply: msg.status === 'auto-replied'
-    };
+      isAutoReply: msg.status === 'auto-replied',
+    }
   }
 
   async createMessage(message: InsertMessage): Promise<Message> {
     if (process.env.DEBUG_AI) {
-      log(`[DEBUG-AI] inserting message ${JSON.stringify(message)}`);
+      log(`[DEBUG-AI] inserting message ${JSON.stringify(message)}`)
     }
 
-    const [newMessage] = await db.insert(messages).values(message).returning();
+    const [newMessage] = await db.insert(messages).values(message).returning()
 
     if (process.env.DEBUG_AI) {
-      log(`[DEBUG-AI] inserted message ${newMessage.id}`);
+      log(`[DEBUG-AI] inserted message ${newMessage.id}`)
     }
 
-    return newMessage;
+    return newMessage
   }
 
   async updateMessageStatus(
-    id: number, 
-    status: string, 
-    reply: string, 
-    isAiGenerated: boolean
+    id: number,
+    status: string,
+    reply: string,
+    isAiGenerated: boolean,
   ): Promise<Message> {
     const [updatedMessage] = await db
       .update(messages)
@@ -407,16 +444,16 @@ export class DatabaseStorage implements IStorage {
         status,
         reply,
         isAiGenerated,
-        replyTimestamp: new Date()
+        replyTimestamp: new Date(),
       })
       .where(eq(messages.id, id))
-      .returning();
-    
+      .returning()
+
     if (!updatedMessage) {
-      throw new Error(`Message with ID ${id} not found`);
+      throw new Error(`Message with ID ${id} not found`)
     }
-    
-    return updatedMessage;
+
+    return updatedMessage
   }
 
   // Settings methods
@@ -424,77 +461,87 @@ export class DatabaseStorage implements IStorage {
     const [existingSettings] = await db
       .select()
       .from(settings)
-      .where(eq(settings.userId, userId));
-    
+      .where(eq(settings.userId, userId))
+
     if (existingSettings) {
-      return existingSettings as Settings;
+      return existingSettings as Settings
     }
-    
+
     // Create default settings with JSON fields if not found
     const defaultSettings: InsertSettings = {
       userId,
       // JSON fields
       apiKeys: {
-        instagram: "",
-        instagramAppId: "",
-        instagramAppSecret: "",
-        instagramUserId: "",
-        instagramPageId: "",
-        instagramWebhookUrl: "",
-        youtube: "",
-        openai: process.env.OPENAI_API_KEY || "",
-        airtable: "",
-        airtableBaseId: "",
-        airtableTableName: "Leads"
+        instagram: '',
+        instagramAppId: '',
+        instagramAppSecret: '',
+        instagramUserId: '',
+        instagramPageId: '',
+        instagramWebhookUrl: '',
+        youtube: '',
+        openai: process.env.OPENAI_API_KEY || '',
+        airtable: '',
+        airtableBaseId: '',
+        airtableTableName: 'Leads',
       },
       aiSettings: {
         temperature: 0.7,
-        creatorToneDescription: "Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.",
+        creatorToneDescription:
+          'Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.',
         maxResponseLength: 500,
-        model: "gpt-4o",
+        model: 'gpt-4o',
         autoReplyInstagram: false,
         autoReplyYoutube: false,
         flexProcessing: false,
-        responseDelay: 0
+        responseDelay: 0,
       },
       notificationSettings: {
-        email: "",
+        email: '',
         notifyOnHighIntent: true,
-        notifyOnSensitiveTopics: true
+        notifyOnSensitiveTopics: true,
       },
-      
+      personaConfig: null,
+      systemPrompt: null,
+
       // Legacy fields (for backward compatibility)
       aiAutoRepliesInstagram: false,
       aiAutoRepliesYoutube: false,
-      instagramToken: "",
-      youtubeToken: "",
-      openaiToken: process.env.OPENAI_API_KEY || "",
-      airtableToken: "",
-      airtableBaseId: "",
-      airtableTableName: "Leads",
-      creatorToneDescription: "Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.",
+      instagramToken: '',
+      youtubeToken: '',
+      openaiToken: process.env.OPENAI_API_KEY || '',
+      airtableToken: '',
+      airtableBaseId: '',
+      airtableTableName: 'Leads',
+      creatorToneDescription:
+        'Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.',
       aiTemperature: 70, // 0.7
-      aiModel: "gpt-4o",
+      aiModel: 'gpt-4o',
       maxResponseLength: 500,
-      notificationEmail: "",
+      notificationEmail: '',
       notifyOnHighIntent: true,
-      notifyOnSensitiveTopics: true
-    };
-    
-      const [newSettings] = await db.insert(settings).values(defaultSettings).returning();
-      return newSettings as Settings;
+      notifyOnSensitiveTopics: true,
+    }
+
+    const [newSettings] = await db
+      .insert(settings)
+      .values(defaultSettings)
+      .returning()
+    return newSettings as Settings
   }
 
-  async updateSettings(userId: number, updates: Partial<Settings>): Promise<Settings> {
-    const existingSettings = await this.getSettings(userId);
-    
+  async updateSettings(
+    userId: number,
+    updates: Partial<Settings>,
+  ): Promise<Settings> {
+    const existingSettings = await this.getSettings(userId)
+
     const [updatedSettings] = await db
       .update(settings)
       .set(updates)
       .where(eq(settings.id, existingSettings.id))
-      .returning();
+      .returning()
 
-    return updatedSettings as Settings;
+    return updatedSettings as Settings
   }
 
   // Automation rules methods
@@ -503,58 +550,55 @@ export class DatabaseStorage implements IStorage {
       .select()
       .from(automationRules)
       .where(eq(automationRules.userId, userId))
-      .orderBy(desc(automationRules.createdAt));
+      .orderBy(desc(automationRules.createdAt))
   }
 
   async getAutomationRule(id: number): Promise<AutomationRule | undefined> {
     const [rule] = await db
       .select()
       .from(automationRules)
-      .where(eq(automationRules.id, id));
-    
-    return rule;
+      .where(eq(automationRules.id, id))
+
+    return rule
   }
 
-  async createAutomationRule(rule: InsertAutomationRule): Promise<AutomationRule> {
-    const [newRule] = await db
-      .insert(automationRules)
-      .values(rule)
-      .returning();
-    
-    return newRule;
+  async createAutomationRule(
+    rule: InsertAutomationRule,
+  ): Promise<AutomationRule> {
+    const [newRule] = await db.insert(automationRules).values(rule).returning()
+
+    return newRule
   }
 
-  async updateAutomationRule(id: number, updates: Partial<AutomationRule>): Promise<AutomationRule | undefined> {
+  async updateAutomationRule(
+    id: number,
+    updates: Partial<AutomationRule>,
+  ): Promise<AutomationRule | undefined> {
     const [updatedRule] = await db
       .update(automationRules)
       .set({
         ...updates,
-        updatedAt: new Date()
+        updatedAt: new Date(),
       })
       .where(eq(automationRules.id, id))
-      .returning();
-    
-    return updatedRule;
+      .returning()
+
+    return updatedRule
   }
 
   async deleteAutomationRule(id: number): Promise<boolean> {
-    await db
-      .delete(automationRules)
-      .where(eq(automationRules.id, id));
-    
+    await db.delete(automationRules).where(eq(automationRules.id, id))
+
     // Check if the rule still exists to determine success
-    const rule = await this.getAutomationRule(id);
-    return rule === undefined;
+    const rule = await this.getAutomationRule(id)
+    return rule === undefined
   }
 
   // Lead methods
   async getLead(id: number): Promise<Lead | undefined> {
-    const [lead] = await db
-      .select()
-      .from(leads)
-      .where(eq(leads.id, id));
-    
-    return lead;
+    const [lead] = await db.select().from(leads).where(eq(leads.id, id))
+
+    return lead
   }
 
   async getLeadsByUserId(userId: number): Promise<Lead[]> {
@@ -562,26 +606,26 @@ export class DatabaseStorage implements IStorage {
       .select()
       .from(leads)
       .where(eq(leads.userId, userId))
-      .orderBy(desc(leads.createdAt));
+      .orderBy(desc(leads.createdAt))
   }
 
   async createLead(lead: InsertLead): Promise<Lead> {
-    const [newLead] = await db
-      .insert(leads)
-      .values(lead)
-      .returning();
-    
-    return newLead;
+    const [newLead] = await db.insert(leads).values(lead).returning()
+
+    return newLead
   }
 
-  async updateLead(id: number, updates: Partial<Lead>): Promise<Lead | undefined> {
+  async updateLead(
+    id: number,
+    updates: Partial<Lead>,
+  ): Promise<Lead | undefined> {
     const [updatedLead] = await db
       .update(leads)
       .set(updates)
       .where(eq(leads.id, id))
-      .returning();
-    
-    return updatedLead;
+      .returning()
+
+    return updatedLead
   }
 
   // Analytics methods
@@ -589,12 +633,12 @@ export class DatabaseStorage implements IStorage {
     const [existingAnalytics] = await db
       .select()
       .from(analytics)
-      .where(eq(analytics.userId, userId));
-    
+      .where(eq(analytics.userId, userId))
+
     if (existingAnalytics) {
-      return existingAnalytics;
+      return existingAnalytics
     }
-    
+
     // Create default analytics if not found
     const defaultAnalytics: InsertAnalytics = {
       userId,
@@ -607,32 +651,35 @@ export class DatabaseStorage implements IStorage {
       avgResponseTimeMinutes: 0,
       highIntentLeadsCount: 0,
       topTopics: [
-        { name: "Pricing", count: 0 },
-        { name: "Features", count: 0 },
-        { name: "Support", count: 0 },
-        { name: "Collaboration", count: 0 },
-        { name: "Feedback", count: 0 }
+        { name: 'Pricing', count: 0 },
+        { name: 'Features', count: 0 },
+        { name: 'Support', count: 0 },
+        { name: 'Collaboration', count: 0 },
+        { name: 'Feedback', count: 0 },
       ],
-      sensitiveTopicsCount: 0
-    };
-    
+      sensitiveTopicsCount: 0,
+    }
+
     const [newAnalytics] = await db
       .insert(analytics)
       .values(defaultAnalytics)
-      .returning();
-    
-    return newAnalytics;
+      .returning()
+
+    return newAnalytics
   }
 
-  async updateAnalytics(userId: number, updates: Partial<Analytics>): Promise<Analytics> {
-    const existingAnalytics = await this.getAnalytics(userId);
-    
+  async updateAnalytics(
+    userId: number,
+    updates: Partial<Analytics>,
+  ): Promise<Analytics> {
+    const existingAnalytics = await this.getAnalytics(userId)
+
     const [updatedAnalytics] = await db
       .update(analytics)
       .set(updates)
       .where(eq(analytics.id, existingAnalytics.id))
-      .returning();
-    
-    return updatedAnalytics;
+      .returning()
+
+    return updatedAnalytics
   }
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,3 @@
-
 // See CHANGELOG.md for 2025-06-09 [Added]
 // See CHANGELOG.md for 2025-06-09 [Changed]
 // See CHANGELOG.md for 2025-06-09 [Fixed]
@@ -16,31 +15,32 @@
 // See CHANGELOG.md for 2025-06-13 [Added-2]
 // See CHANGELOG.md for 2025-06-12 [Changed-2]
 // See CHANGELOG.md for 2025-06-17 [Changed]
-import type { Express } from "express";
-import { faker } from "@faker-js/faker";
-import { createServer, type Server } from "http";
-import { storage } from "./storage";
+import type { Express } from 'express'
+import { faker } from '@faker-js/faker'
+import { createServer, type Server } from 'http'
+import { storage } from './storage'
 // See CHANGELOG.md for 2025-06-13 [Fixed-2]
-import { db } from "./db";
-import { z } from "zod";
-import { messages } from "@shared/schema";
-import { eq, sql } from "drizzle-orm";
-import { instagramService } from "./services/instagram";
-import { youtubeService } from "./services/youtube";
-import { airtableService } from "./services/airtable";
-import { aiService } from "./services/openai";
-import { contentService } from "./services/content";
-import { oauthService } from "./services/oauth";
-import { log } from "./logger";
+import { db } from './db'
+import { z } from 'zod'
+import { messages } from '@shared/schema'
+import { eq, sql } from 'drizzle-orm'
+import { instagramService } from './services/instagram'
+import { youtubeService } from './services/youtube'
+import { airtableService } from './services/airtable'
+import { aiService } from './services/openai'
+import { contentService } from './services/content'
+import { oauthService } from './services/oauth'
+import { log } from './logger'
+import { buildSystemPrompt } from './utils/prompt'
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Threaded messages API endpoint with recursive SQL
   app.get('/api/messages/threaded', async (req, res) => {
     try {
-      const { conversationId } = req.query;
-      
+      const { conversationId } = req.query
+
       if (!conversationId) {
-        return res.status(400).json({ error: 'conversationId is required' });
+        return res.status(400).json({ error: 'conversationId is required' })
       }
 
       // Recursive SQL query to get all messages with their parent-child relationships
@@ -76,11 +76,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         )
         SELECT * FROM message_tree 
         ORDER BY path, timestamp
-      `);
+      `)
 
       // Build nested structure from flat results
-      const messageMap = new Map();
-      const rootMessages = [];
+      const messageMap = new Map()
+      const rootMessages = []
 
       // First pass: create all message objects
       for (const row of flatMessages.rows) {
@@ -91,88 +91,105 @@ export async function registerRoutes(app: Express): Promise<Server> {
           senderId: row.sender_id,
           parentMessageId: row.parent_message_id,
           depth: row.depth,
-          replies: []
-        };
-        messageMap.set(row.id, message);
+          replies: [],
+        }
+        messageMap.set(row.id, message)
       }
 
       // Second pass: build the tree structure
       for (const row of flatMessages.rows) {
-        const message = messageMap.get(row.id);
-        
+        const message = messageMap.get(row.id)
+
         if (row.parent_message_id && messageMap.has(row.parent_message_id)) {
           // This is a reply - add to parent's replies array
-          const parent = messageMap.get(row.parent_message_id);
-          parent.replies.push(message);
+          const parent = messageMap.get(row.parent_message_id)
+          parent.replies.push(message)
         } else {
           // This is a root message
-          rootMessages.push(message);
+          rootMessages.push(message)
         }
       }
 
-      res.json(rootMessages);
+      res.json(rootMessages)
     } catch (error) {
-      console.error('Error fetching threaded messages:', error);
-      res.status(500).json({ error: 'Failed to fetch threaded messages' });
+      console.error('Error fetching threaded messages:', error)
+      res.status(500).json({ error: 'Failed to fetch threaded messages' })
     }
-  });
+  })
 
   // Test messaging endpoints - Using storage methods
   app.post('/api/test/generate-messages', async (req, res) => {
     try {
       const generateRandomMessages = (count: number) => {
-        const messages = [];
-        
+        const messages = []
+
         // Arrays for more realistic test data
-        const instagramNames = ["Sophia Ross", "Liam Chen", "Emma Johnson", "Noah Garcia", "Olivia Kim"];
-        const youtubeNames = ["Alex Taylor", "Mia Williams", "Lucas Brown", "Madison Lee", "Daniel Rodriguez"];
+        const instagramNames = [
+          'Sophia Ross',
+          'Liam Chen',
+          'Emma Johnson',
+          'Noah Garcia',
+          'Olivia Kim',
+        ]
+        const youtubeNames = [
+          'Alex Taylor',
+          'Mia Williams',
+          'Lucas Brown',
+          'Madison Lee',
+          'Daniel Rodriguez',
+        ]
         const avatars = [
-          "https://images.unsplash.com/photo-1580489944761-15a19d654956",
-          "https://images.unsplash.com/photo-1535713875002-d1d0cf377fde",
-          "https://images.unsplash.com/photo-1438761681033-6461ffad8d80",
-          "https://images.unsplash.com/photo-1539571696357-5a69c17a67c6",
-          "https://images.unsplash.com/photo-1534528741775-53994a69daeb",
-          "https://images.unsplash.com/photo-1506794778202-cad84cf45f1d"
-        ];
-        
+          'https://images.unsplash.com/photo-1580489944761-15a19d654956',
+          'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde',
+          'https://images.unsplash.com/photo-1438761681033-6461ffad8d80',
+          'https://images.unsplash.com/photo-1539571696357-5a69c17a67c6',
+          'https://images.unsplash.com/photo-1534528741775-53994a69daeb',
+          'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d',
+        ]
+
         const instagramContents = [
           "Hi there! Just discovered your profile through a friend. Your content is exactly what I've been looking for!",
           "Your latest post really resonated with me. I've been following your work for months and it keeps getting better!",
-          "Quick question - do you offer any tips for beginners who are just starting out? Love your approach!",
-          "Been a fan for a while now. Your aesthetic and style are so unique compared to others in this space.",
-          "The way you explained that concept in your latest post was so clear. I finally understand it now!",
-          "Just wanted to say your page has been incredibly helpful for me as I navigate this industry. Thank you!",
-          "Do you ever do meetups or live sessions? Would love to connect!"
-        ];
-        
+          'Quick question - do you offer any tips for beginners who are just starting out? Love your approach!',
+          'Been a fan for a while now. Your aesthetic and style are so unique compared to others in this space.',
+          'The way you explained that concept in your latest post was so clear. I finally understand it now!',
+          'Just wanted to say your page has been incredibly helpful for me as I navigate this industry. Thank you!',
+          'Do you ever do meetups or live sessions? Would love to connect!',
+        ]
+
         const youtubeContents = [
           "Your latest video was really helpful! Any chance you'll do a follow-up on more advanced techniques?",
-          "Been watching your channel for months now. The quality just keeps improving! Love your editing style.",
-          "That tutorial saved me so much time. Would you consider doing one on related tools as well?",
-          "I tried the method you shared and it worked perfectly. Thanks for the detailed walkthrough!",
-          "Quick question about something you mentioned at 5:23 in your latest video. Did you mean...?",
-          "Your explanation was way clearer than anything else I found online. Subscribed immediately!",
-          "Finally a channel that explains these concepts in a way that makes sense. Keep it up!"
-        ];
-        
+          'Been watching your channel for months now. The quality just keeps improving! Love your editing style.',
+          'That tutorial saved me so much time. Would you consider doing one on related tools as well?',
+          'I tried the method you shared and it worked perfectly. Thanks for the detailed walkthrough!',
+          'Quick question about something you mentioned at 5:23 in your latest video. Did you mean...?',
+          'Your explanation was way clearer than anything else I found online. Subscribed immediately!',
+          'Finally a channel that explains these concepts in a way that makes sense. Keep it up!',
+        ]
+
         for (let i = 0; i < count; i++) {
-          const isInstagram = Math.random() > 0.4; // 60% Instagram, 40% YouTube
-          const isHighIntent = Math.random() > 0.8; // 20% high intent messages
-          
-          const randomTimestampOffset = Math.floor(Math.random() * 120) * 60000; // Random offset up to 120 minutes
-          const timestamp = new Date(Date.now() - randomTimestampOffset);
-          
-          const source = isInstagram ? "instagram" : "youtube";
-          const nameArray = isInstagram ? instagramNames : youtubeNames;
-          const contentArray = isInstagram ? instagramContents : youtubeContents;
-          
-          const senderName = nameArray[Math.floor(Math.random() * nameArray.length)];
-          const content = contentArray[Math.floor(Math.random() * contentArray.length)];
-          const avatar = avatars[Math.floor(Math.random() * avatars.length)];
-          
+          const isInstagram = Math.random() > 0.4 // 60% Instagram, 40% YouTube
+          const isHighIntent = Math.random() > 0.8 // 20% high intent messages
+
+          const randomTimestampOffset = Math.floor(Math.random() * 120) * 60000 // Random offset up to 120 minutes
+          const timestamp = new Date(Date.now() - randomTimestampOffset)
+
+          const source = isInstagram ? 'instagram' : 'youtube'
+          const nameArray = isInstagram ? instagramNames : youtubeNames
+          const contentArray = isInstagram ? instagramContents : youtubeContents
+
+          const senderName =
+            nameArray[Math.floor(Math.random() * nameArray.length)]
+          const content =
+            contentArray[Math.floor(Math.random() * contentArray.length)]
+          const avatar = avatars[Math.floor(Math.random() * avatars.length)]
+
           // Create a unique but readable ID for the sender
-          const senderId = senderName.toLowerCase().replace(/\s+/g, '.') + '.' + Math.floor(Math.random() * 1000);
-          
+          const senderId =
+            senderName.toLowerCase().replace(/\s+/g, '.') +
+            '.' +
+            Math.floor(Math.random() * 1000)
+
           messages.push({
             source,
             content,
@@ -181,108 +198,121 @@ export async function registerRoutes(app: Express): Promise<Server> {
             senderName,
             senderAvatar: avatar,
             timestamp,
-            status: "new",
+            status: 'new',
             isHighIntent,
-            intentCategory: isHighIntent ? 
-              (Math.random() > 0.5 ? "collaboration" : "purchase_interest") : undefined,
-            intentConfidence: isHighIntent ? Math.floor(70 + Math.random() * 30) : undefined,
-            userId: 1
-          });
+            intentCategory: isHighIntent
+              ? Math.random() > 0.5
+                ? 'collaboration'
+                : 'purchase_interest'
+              : undefined,
+            intentConfidence: isHighIntent
+              ? Math.floor(70 + Math.random() * 30)
+              : undefined,
+            userId: 1,
+          })
         }
-        
-        return messages;
-      };
-      
+
+        return messages
+      }
+
       // Generate 10 random messages
-      const messages = generateRandomMessages(10);
-      
+      const messages = generateRandomMessages(10)
+
       // Create all the messages
       for (const message of messages) {
-        await storage.createMessage(message);
+        await storage.createMessage(message)
       }
-      
-      res.json({ success: true, count: messages.length });
+
+      res.json({ success: true, count: messages.length })
     } catch (error) {
-      console.error('Error generating test messages:', error);
-      res.status(500).json({ success: false, error: String(error) });
+      console.error('Error generating test messages:', error)
+      res.status(500).json({ success: false, error: String(error) })
     }
-  });
-  
+  })
+
   app.post('/api/test/generate-high-intent', async (req, res) => {
     try {
       // Array of high-intent messages for better testing
       const highIntentMessages = [
         {
-          source: "instagram",
-          content: "Hi there! I am really interested in working with you. Can you tell me more about your pricing and availability? I would love to get started as soon as possible!",
-          senderName: "Jamie Wilson",
-          intentCategory: "purchase_interest",
-          intentConfidence: 95
+          source: 'instagram',
+          content:
+            'Hi there! I am really interested in working with you. Can you tell me more about your pricing and availability? I would love to get started as soon as possible!',
+          senderName: 'Jamie Wilson',
+          intentCategory: 'purchase_interest',
+          intentConfidence: 95,
         },
         {
-          source: "instagram",
-          content: "Your portfolio is exactly what I've been looking for. I've got a project with a $5k budget and a tight deadline - could we schedule a call to discuss the details?",
-          senderName: "Taylor Reynolds",
-          intentCategory: "purchase_interest",
-          intentConfidence: 98
+          source: 'instagram',
+          content:
+            "Your portfolio is exactly what I've been looking for. I've got a project with a $5k budget and a tight deadline - could we schedule a call to discuss the details?",
+          senderName: 'Taylor Reynolds',
+          intentCategory: 'purchase_interest',
+          intentConfidence: 98,
         },
         {
-          source: "youtube",
-          content: "I represent a lifestyle brand and we're looking for someone with your talent for our next campaign. What would be the best way to discuss collaboration opportunities?",
-          senderName: "Jordan Martinez",
-          intentCategory: "collaboration",
-          intentConfidence: 92
-        }
-      ];
-      
+          source: 'youtube',
+          content:
+            "I represent a lifestyle brand and we're looking for someone with your talent for our next campaign. What would be the best way to discuss collaboration opportunities?",
+          senderName: 'Jordan Martinez',
+          intentCategory: 'collaboration',
+          intentConfidence: 92,
+        },
+      ]
+
       // Choose a random high-intent message
-      const randomMessage = highIntentMessages[Math.floor(Math.random() * highIntentMessages.length)];
-      
+      const randomMessage =
+        highIntentMessages[
+          Math.floor(Math.random() * highIntentMessages.length)
+        ]
+
       // Random avatar selection
       const avatars = [
-        "https://images.unsplash.com/photo-1560250097-0b93528c311a",
-        "https://images.unsplash.com/photo-1573497019236-17f8177b81e8",
-        "https://images.unsplash.com/photo-1573496358961-3c82861ab8f4"
-      ];
-      const avatar = avatars[Math.floor(Math.random() * avatars.length)];
-      
+        'https://images.unsplash.com/photo-1560250097-0b93528c311a',
+        'https://images.unsplash.com/photo-1573497019236-17f8177b81e8',
+        'https://images.unsplash.com/photo-1573496358961-3c82861ab8f4',
+      ]
+      const avatar = avatars[Math.floor(Math.random() * avatars.length)]
+
       // Create the senderId from the sender name
-      const senderId = randomMessage.senderName.toLowerCase().replace(/\s+/g, '.') + '.' + 
-        Math.floor(Math.random() * 1000);
-      
+      const senderId =
+        randomMessage.senderName.toLowerCase().replace(/\s+/g, '.') +
+        '.' +
+        Math.floor(Math.random() * 1000)
+
       // Create a high-intent message using the storage layer
       await storage.createMessage({
         source: randomMessage.source,
         content: randomMessage.content,
-        externalId: "high-intent-" + Date.now(),
+        externalId: 'high-intent-' + Date.now(),
         senderId,
         senderName: randomMessage.senderName,
         senderAvatar: avatar,
         timestamp: new Date(),
-        status: "new",
+        status: 'new',
         isHighIntent: true,
         intentCategory: randomMessage.intentCategory,
         intentConfidence: randomMessage.intentConfidence,
-        userId: 1
-      });
-      
-      res.json({ success: true });
+        userId: 1,
+      })
+
+      res.json({ success: true })
     } catch (error) {
-      console.error('Error generating high-intent message:', error);
-      res.status(500).json({ success: false, error: String(error) });
+      console.error('Error generating high-intent message:', error)
+      res.status(500).json({ success: false, error: String(error) })
     }
-  });
+  })
 
   app.post('/api/test/generate-batch', async (_req, res) => {
     try {
       if (process.env.DEBUG_AI) {
-        console.debug('[DEBUG-AI] starting batch generation');
+        console.debug('[DEBUG-AI] starting batch generation')
       }
 
-      const messages = [] as any[];
-      const highIntentIndexes = new Set<number>();
+      const messages = [] as any[]
+      const highIntentIndexes = new Set<number>()
       while (highIntentIndexes.size < 3) {
-        highIntentIndexes.add(Math.floor(Math.random() * 10));
+        highIntentIndexes.add(Math.floor(Math.random() * 10))
       }
 
       for (let i = 0; i < 10; i++) {
@@ -290,7 +320,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const source = Math.random() > 0.5 ? 'instagram' : 'youtube'
 
         if (process.env.DEBUG_AI) {
-          console.debug('[DEBUG-AI] creating message', { index: i, isHighIntent, source })
+          console.debug('[DEBUG-AI] creating message', {
+            index: i,
+            isHighIntent,
+            source,
+          })
         }
 
         const senderId = faker.internet.userName().toLowerCase()
@@ -302,7 +336,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           senderId,
           senderName,
           source,
-          senderAvatar
+          senderAvatar,
         )
 
         const message = await storage.addMessageToThread(thread.id, {
@@ -324,43 +358,49 @@ export async function registerRoutes(app: Express): Promise<Server> {
         })
 
         if (process.env.DEBUG_AI) {
-          console.debug('[DEBUG-AI] created message', { id: message.id, threadId: thread.id })
+          console.debug('[DEBUG-AI] created message', {
+            id: message.id,
+            threadId: thread.id,
+          })
         }
 
         messages.push(message)
       }
 
       if (process.env.DEBUG_AI) {
-        console.debug('[DEBUG-AI] batch generation complete', { count: messages.length });
+        console.debug('[DEBUG-AI] batch generation complete', {
+          count: messages.length,
+        })
       }
 
-      res.json({ success: true, count: messages.length });
+      res.json({ success: true, count: messages.length })
     } catch (err) {
-      console.error('Error generating batch:', err);
+      console.error('Error generating batch:', err)
       if (process.env.DEBUG_AI) {
-        console.error('[DEBUG-AI] batch generation failed', err);
+        console.error('[DEBUG-AI] batch generation failed', err)
       }
-      res.status(500).json({ success: false, error: String(err) });
+      res.status(500).json({ success: false, error: String(err) })
     }
-  });
+  })
 
   // See CHANGELOG.md for 2025-06-10 [Added]
   // See CHANGELOG.md for 2025-06-10 [Fixed]
   app.post('/api/test/generate-for-user/:threadId', async (req, res) => {
     try {
-      const threadId = parseInt(req.params.threadId);
-      const thread = await storage.getThread(threadId);
+      const threadId = parseInt(req.params.threadId)
+      const thread = await storage.getThread(threadId)
       if (!thread) {
-        return res.status(404).json({ message: 'Thread not found' });
+        return res.status(404).json({ message: 'Thread not found' })
       }
 
       const content =
-        typeof req.body.content === 'string' && req.body.content.trim().length > 0
+        typeof req.body.content === 'string' &&
+        req.body.content.trim().length > 0
           ? req.body.content
-          : undefined;
+          : undefined
 
       const messageContent =
-        content ?? `Hi ${thread.participantName}, this is a test message.`;
+        content ?? `Hi ${thread.participantName}, this is a test message.`
 
       const rawMsg = await storage.addMessageToThread(threadId, {
         source: thread.source || 'instagram',
@@ -374,7 +414,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         isHighIntent: false,
         userId: thread.userId,
         metadata: {},
-      });
+      })
 
       const mapped = {
         id: rawMsg.id,
@@ -391,16 +431,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
         reply: rawMsg.reply ?? undefined,
         threadId: rawMsg.threadId ?? undefined,
         parentMessageId:
-          rawMsg.parentMessageId !== undefined && rawMsg.parentMessageId !== null
+          rawMsg.parentMessageId !== undefined &&
+          rawMsg.parentMessageId !== null
             ? Number(rawMsg.parentMessageId)
             : undefined,
         isOutbound: rawMsg.isOutbound || false,
         isAiGenerated: rawMsg.isAiGenerated ?? false,
-      };
+      }
 
       // Auto-reply logic mirroring Instagram webhook
-      const settings = await storage.getSettings(thread.userId);
-      const aiSettings = settings.aiSettings as any;
+      const settings = await storage.getSettings(thread.userId)
+      const aiSettings = settings.aiSettings as any
 
       if (aiSettings?.autoReplyInstagram && thread.autoReply) {
         const aiReplyContent = await aiService.generateReply({
@@ -411,7 +452,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           maxLength: aiSettings.maxResponseLength ?? 500,
           model: aiSettings.model ?? 'gpt-4o',
           flexProcessing: aiSettings.flexProcessing ?? false,
-        });
+        })
 
         await storage.addMessageToThread(threadId, {
           source: 'instagram',
@@ -426,403 +467,411 @@ export async function registerRoutes(app: Express): Promise<Server> {
           isAiGenerated: true,
           userId: thread.userId,
           metadata: {},
-        });
+        })
       }
 
-      res.json(mapped);
+      res.json(mapped)
     } catch (err) {
-      console.error('Error generating for user:', err);
-      res.status(500).json({ success: false, error: String(err) });
+      console.error('Error generating for user:', err)
+      res.status(500).json({ success: false, error: String(err) })
     }
-  });
+  })
 
   // Thread-based message endpoints
   app.get('/api/threads', async (req, res) => {
     try {
-      const source = req.query.source as string | undefined;
-      const threads = await storage.getThreads(1, source);
-      res.json(threads);
+      const source = req.query.source as string | undefined
+      const threads = await storage.getThreads(1, source)
+      res.json(threads)
     } catch (error) {
-      console.error("Error fetching threads:", error);
-      res.status(500).json({ message: "Failed to fetch message threads" });
+      console.error('Error fetching threads:', error)
+      res.status(500).json({ message: 'Failed to fetch message threads' })
     }
-  });
+  })
 
   app.get('/api/threads/:id', async (req, res) => {
     try {
-      const threadId = parseInt(req.params.id);
-      const thread = await storage.getThread(threadId);
-      
+      const threadId = parseInt(req.params.id)
+      const thread = await storage.getThread(threadId)
+
       if (!thread) {
-        return res.status(404).json({ message: "Thread not found" });
+        return res.status(404).json({ message: 'Thread not found' })
       }
-      
-      res.json(thread);
+
+      res.json(thread)
     } catch (error) {
-      console.error("Error fetching thread:", error);
-      res.status(500).json({ message: "Failed to fetch thread" });
+      console.error('Error fetching thread:', error)
+      res.status(500).json({ message: 'Failed to fetch thread' })
     }
-  });
+  })
 
   app.get('/api/threads/:id/messages', async (req, res) => {
     try {
-      const threadId = parseInt(req.params.id);
-      log(`Fetching messages for thread ID: ${threadId}`);
-      
+      const threadId = parseInt(req.params.id)
+      log(`Fetching messages for thread ID: ${threadId}`)
+
       // Get messages from storage
-      const threadMessages = await storage.getThreadMessages(threadId);
-      
+      const threadMessages = await storage.getThreadMessages(threadId)
+
       // More detailed logging to trace parent-child relationships
-      log(`Thread #${threadId} contains ${threadMessages.length} messages`);
-      
+      log(`Thread #${threadId} contains ${threadMessages.length} messages`)
+
       // Track parent-child relationships for better debugging
-      const parentMap = new Map();
-      const childrenMap = new Map();
-      
+      const parentMap = new Map()
+      const childrenMap = new Map()
+
       // First pass - identify all parent-child relationships
-      threadMessages.forEach(msg => {
+      threadMessages.forEach((msg) => {
         if (msg.parentMessageId) {
           // This is a reply
           if (!childrenMap.has(msg.parentMessageId)) {
-            childrenMap.set(msg.parentMessageId, []);
+            childrenMap.set(msg.parentMessageId, [])
           }
-          childrenMap.get(msg.parentMessageId).push(msg.id);
-          parentMap.set(msg.id, msg.parentMessageId);
-          
-          log(`Message ${msg.id} is a reply to parent ${msg.parentMessageId}`);
+          childrenMap.get(msg.parentMessageId).push(msg.id)
+          parentMap.set(msg.id, msg.parentMessageId)
+
+          log(`Message ${msg.id} is a reply to parent ${msg.parentMessageId}`)
         } else {
-          log(`Message ${msg.id} is a top-level message`);
+          log(`Message ${msg.id} is a top-level message`)
         }
-      });
-      
+      })
+
       // Log detailed information with full message content
       log(
         `Thread messages with parentIds: ${JSON.stringify(
-          threadMessages.map(m => ({
+          threadMessages.map((m) => ({
             id: m.id,
-            content: (m.content || "").substring(0, 50),
+            content: (m.content || '').substring(0, 50),
             parentId: m.parentMessageId,
             isReply: !!m.parentMessageId,
             hasReplies: childrenMap.has(m.id),
-            timestamp: m.timestamp
-          }))
-        )}`
-      );
-      
+            timestamp: m.timestamp,
+          })),
+        )}`,
+      )
+
       // Make sure all messages have parentMessageId explicitly set as a number or null
-      const processedMessages = threadMessages.map(message => {
-        let parentId = null;
-        if (message.parentMessageId !== undefined && message.parentMessageId !== null) {
-          parentId = Number(message.parentMessageId);
+      const processedMessages = threadMessages.map((message) => {
+        let parentId = null
+        if (
+          message.parentMessageId !== undefined &&
+          message.parentMessageId !== null
+        ) {
+          parentId = Number(message.parentMessageId)
           if (isNaN(parentId)) {
-            parentId = null;
+            parentId = null
           }
         }
-        
+
         return {
           ...message,
           // Ensure parentMessageId is a number (not a string) or null
-          parentMessageId: parentId
-        };
-      });
-      
+          parentMessageId: parentId,
+        }
+      })
+
       log(
         `Processed messages with parentIds: ${JSON.stringify(
-          processedMessages.map(m => ({
+          processedMessages.map((m) => ({
             id: m.id,
             parentId: m.parentMessageId,
-            type: typeof m.parentMessageId
-          }))
-        )}`
-      );
-      
-      res.json(processedMessages);
+            type: typeof m.parentMessageId,
+          })),
+        )}`,
+      )
+
+      res.json(processedMessages)
     } catch (error) {
-      console.error("Error fetching thread messages:", error);
-      res.status(500).json({ message: "Failed to fetch thread messages" });
+      console.error('Error fetching thread messages:', error)
+      res.status(500).json({ message: 'Failed to fetch thread messages' })
     }
-  });
+  })
 
   app.post('/api/threads/:id/read', async (req, res) => {
     try {
-      const threadId = parseInt(req.params.id);
-      const result = await storage.markThreadAsRead(threadId);
-      res.json({ success: result });
+      const threadId = parseInt(req.params.id)
+      const result = await storage.markThreadAsRead(threadId)
+      res.json({ success: result })
     } catch (error) {
-      console.error("Error marking thread as read:", error);
-      res.status(500).json({ message: "Failed to mark thread as read" });
+      console.error('Error marking thread as read:', error)
+      res.status(500).json({ message: 'Failed to mark thread as read' })
     }
-  });
+  })
 
   app.post('/api/threads/:id/reply', async (req, res) => {
     try {
-      const threadId = parseInt(req.params.id);
-      const { content, parentMessageId } = req.body;
-      
+      const threadId = parseInt(req.params.id)
+      const { content, parentMessageId } = req.body
+
       if (!content) {
-        return res.status(400).json({ message: "Message content is required" });
+        return res.status(400).json({ message: 'Message content is required' })
       }
-      
+
       // Get thread to determine source
-      const thread = await storage.getThread(threadId);
+      const thread = await storage.getThread(threadId)
       if (!thread) {
-        return res.status(404).json({ message: "Thread not found" });
+        return res.status(404).json({ message: 'Thread not found' })
       }
-      
+
       // Ensure parentMessageId is properly handled
-      let parentId = null;
+      let parentId = null
 
       if (parentMessageId !== undefined && parentMessageId !== null) {
-        parentId = Number(parentMessageId);
+        parentId = Number(parentMessageId)
 
         // Treat 0 as null to maintain proper root messages
         if (isNaN(parentId) || parentId === 0) {
-          parentId = null;
+          parentId = null
         }
       }
-      
-      log(`Creating reply to message ${parentId}, original value: ${parentMessageId}`);
-      
+
+      log(
+        `Creating reply to message ${parentId}, original value: ${parentMessageId}`,
+      )
+
       // Create outbound message (creator's reply)
       const message = await storage.addMessageToThread(threadId, {
         content,
-        source: thread.source || "instagram",
+        source: thread.source || 'instagram',
         isOutbound: true,
-        status: "replied",
-        parentMessageId: parentId,  // Use properly validated parentId
+        status: 'replied',
+        parentMessageId: parentId, // Use properly validated parentId
         isHighIntent: false,
-        senderName: "Creator",
-        senderId: "creator-id",
+        senderName: 'Creator',
+        senderId: 'creator-id',
         senderAvatar: null,
         externalId: `reply-${Date.now()}`,
         metadata: {},
         isAiGenerated: false,
-        userId: 1
-      });
-      
-      res.json(message);
+        userId: 1,
+      })
+
+      res.json(message)
     } catch (error) {
-      console.error("Error sending reply:", error);
-      res.status(500).json({ message: "Failed to send reply" });
+      console.error('Error sending reply:', error)
+      res.status(500).json({ message: 'Failed to send reply' })
     }
-  });
+  })
 
   app.post('/api/threads/:id/generate-reply', async (req, res) => {
     try {
-      const threadId = parseInt(req.params.id);
-      const thread = await storage.getThread(threadId);
-      
+      const threadId = parseInt(req.params.id)
+      const thread = await storage.getThread(threadId)
+
       if (!thread) {
-        return res.status(404).json({ message: "Thread not found" });
+        return res.status(404).json({ message: 'Thread not found' })
       }
-      
+
       // Get thread messages for context
-      const messages = await storage.getThreadMessages(threadId);
-      
+      const messages = await storage.getThreadMessages(threadId)
+
       // Get settings for AI parameters
-      const settings = await storage.getSettings(1);
-      
+      const settings = await storage.getSettings(1)
+
       // Generate AI reply using the OpenAI service and creator settings
       const generatedReply = await aiService.generateReply({
-        content: messages[messages.length - 1]?.content ?? "",
+        content: messages[messages.length - 1]?.content ?? '',
         senderName: thread.participantName,
-        creatorToneDescription: settings.creatorToneDescription || "",
+        creatorToneDescription: settings.creatorToneDescription || '',
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 300,
-        model: settings.aiSettings?.model || "gpt-4o",
-        flexProcessing: settings.aiSettings?.flexProcessing || false
-      });
-      
-      res.json({ generatedReply });
+        model: settings.aiSettings?.model || 'gpt-4o',
+        flexProcessing: settings.aiSettings?.flexProcessing || false,
+      })
+
+      res.json({ generatedReply })
     } catch (error) {
-      console.error("Error generating AI reply:", error);
-      res.status(500).json({ message: "Failed to generate AI reply" });
+      console.error('Error generating AI reply:', error)
+      res.status(500).json({ message: 'Failed to generate AI reply' })
     }
-  });
+  })
 
   app.post('/api/threads/:id/status', async (req, res) => {
     try {
-      const threadId = parseInt(req.params.id);
-      const { status } = req.body;
-      
+      const threadId = parseInt(req.params.id)
+      const { status } = req.body
+
       if (!status || !['active', 'archived', 'snoozed'].includes(status)) {
-        return res.status(400).json({ message: "Invalid status" });
+        return res.status(400).json({ message: 'Invalid status' })
       }
-      
-      const updatedThread = await storage.updateThread(threadId, { status });
-      res.json(updatedThread);
+
+      const updatedThread = await storage.updateThread(threadId, { status })
+      res.json(updatedThread)
     } catch (error) {
-      console.error("Error updating thread status:", error);
-      res.status(500).json({ message: "Failed to update thread status" });
+      console.error('Error updating thread status:', error)
+      res.status(500).json({ message: 'Failed to update thread status' })
     }
-  });
+  })
 
-// See CHANGELOG.md for 2025-06-15 [Added] – toggle auto-reply on a thread
-app.patch('/api/threads/:id/auto-reply', async (req, res) => {
-  try {
-    const threadId = Number(req.params.id);
+  // See CHANGELOG.md for 2025-06-15 [Added] – toggle auto-reply on a thread
+  app.patch('/api/threads/:id/auto-reply', async (req, res) => {
+    try {
+      const threadId = Number(req.params.id)
 
-    const Body = z.object({ autoReply: z.boolean() }).strict();
-    const { autoReply } = Body.parse(req.body);
+      const Body = z.object({ autoReply: z.boolean() }).strict()
+      const { autoReply } = Body.parse(req.body)
 
-    const updatedThread = await storage.updateThread(threadId, {
-      autoReply,
-    });
+      const updatedThread = await storage.updateThread(threadId, {
+        autoReply,
+      })
 
-    if (!updatedThread) {
-      return res.status(404).json({ message: 'Thread not found' });
+      if (!updatedThread) {
+        return res.status(404).json({ message: 'Thread not found' })
+      }
+
+      return res.json({ message: 'Auto-reply updated', thread: updatedThread })
+    } catch (err: any) {
+      console.error('Error updating auto-reply:', err)
+      return res
+        .status(500)
+        .json({ message: 'Failed to update auto-reply setting' })
     }
-
-    return res.json({ message: 'Auto-reply updated', thread: updatedThread });
-  } catch (err: any) {
-    console.error('Error updating auto-reply:', err);
-    return res
-      .status(500)
-      .json({ message: 'Failed to update auto-reply setting' });
-  }
-});
+  })
 
   app.delete('/api/threads/:id', async (req, res) => {
     try {
-      const threadId = parseInt(req.params.id);
-      const success = await storage.deleteThread(threadId);
+      const threadId = parseInt(req.params.id)
+      const success = await storage.deleteThread(threadId)
       if (!success) {
-        return res.status(404).json({ message: 'Thread not found' });
+        return res.status(404).json({ message: 'Thread not found' })
       }
-      res.json({ success: true });
+      res.json({ success: true })
     } catch (error) {
-      console.error('Error deleting thread:', error);
-      res.status(500).json({ message: 'Failed to delete thread' });
+      console.error('Error deleting thread:', error)
+      res.status(500).json({ message: 'Failed to delete thread' })
     }
-  });
+  })
 
   // API endpoints to get messages from different platforms
   app.get('/api/messages/instagram', async (req, res) => {
     try {
       // Use the storage interface to get all Instagram messages
-      const messages = await storage.getInstagramMessages();
-      res.json(messages);
+      const messages = await storage.getInstagramMessages()
+      res.json(messages)
     } catch (error) {
-      console.error('Error fetching Instagram messages:', error);
-      res.status(500).json({ error: String(error) });
+      console.error('Error fetching Instagram messages:', error)
+      res.status(500).json({ error: String(error) })
     }
-  });
-  
+  })
+
   app.get('/api/messages/youtube', async (req, res) => {
     try {
       // Use the storage interface to get all YouTube messages
-      const messages = await storage.getYoutubeMessages();
-      res.json(messages);
+      const messages = await storage.getYoutubeMessages()
+      res.json(messages)
     } catch (error) {
-      console.error('Error fetching YouTube messages:', error);
-      res.status(500).json({ error: String(error) });
+      console.error('Error fetching YouTube messages:', error)
+      res.status(500).json({ error: String(error) })
     }
-  });
+  })
 
   app.delete('/api/messages/:id', async (req, res) => {
     try {
-      const messageId = parseInt(req.params.id);
-      const success = await storage.deleteMessage(messageId);
+      const messageId = parseInt(req.params.id)
+      const success = await storage.deleteMessage(messageId)
       if (!success) {
-        return res.status(404).json({ message: 'Message not found' });
+        return res.status(404).json({ message: 'Message not found' })
       }
-      res.json({ success: true });
+      res.json({ success: true })
     } catch (error) {
-      console.error('Error deleting message:', error);
-      res.status(500).json({ message: 'Failed to delete message' });
+      console.error('Error deleting message:', error)
+      res.status(500).json({ message: 'Failed to delete message' })
     }
-  });
-  
+  })
+
   // Generate AI reply for any message type
   app.post('/api/messages/:id/generate-reply', async (req, res) => {
     try {
       if (process.env.DEBUG_AI) {
         console.debug('[DEBUG-AI] POST /api/messages/:id/generate-reply', {
-          id: req.params.id
-        });
+          id: req.params.id,
+        })
       }
-      const messageId = parseInt(req.params.id);
+      const messageId = parseInt(req.params.id)
       if (isNaN(messageId)) {
-        return res.status(400).json({ message: 'Invalid message ID' });
+        return res.status(400).json({ message: 'Invalid message ID' })
       }
-      
+
       // Get the message
-      const message = await storage.getMessage(messageId);
+      const message = await storage.getMessage(messageId)
       if (!message) {
-        return res.status(404).json({ message: 'Message not found' });
+        return res.status(404).json({ message: 'Message not found' })
       }
-      
+
       // Get user settings
-      const settings = await storage.getSettings(1); // Default to user ID 1 for MVP
-      
+      const settings = await storage.getSettings(1) // Default to user ID 1 for MVP
+
       // Sample context snippets for the creator's tone and style
       const contextSnippets = [
-        "I prefer responding with energy and positivity to all comments.",
-        "I always thank my audience for engaging and ask follow-up questions.",
-        "My brand voice is friendly, approachable, and slightly humorous."
-      ];
-      
+        'I prefer responding with energy and positivity to all comments.',
+        'I always thank my audience for engaging and ask follow-up questions.',
+        'My brand voice is friendly, approachable, and slightly humorous.',
+      ]
+
       // Generate AI reply without sending it yet
       const aiReply = await aiService.generateReply({
         content: message.content,
         senderName: message.senderName,
-        creatorToneDescription: settings.creatorToneDescription || "Friendly and professional",
+        creatorToneDescription:
+          settings.creatorToneDescription || 'Friendly and professional',
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 300,
         contextSnippets,
-        model: settings.aiSettings?.model || "gpt-4o",
-        flexProcessing: settings.aiSettings?.flexProcessing || false
-      });
+        model: settings.aiSettings?.model || 'gpt-4o',
+        flexProcessing: settings.aiSettings?.flexProcessing || false,
+      })
 
       if (process.env.DEBUG_AI) {
-        console.debug('[DEBUG-AI] generated reply', aiReply);
+        console.debug('[DEBUG-AI] generated reply', aiReply)
       }
-      
+
       // Return only the generated reply
-      return res.json({ 
+      return res.json({
         generatedReply: aiReply,
-        success: true 
-      });
-      
+        success: true,
+      })
     } catch (error) {
-      console.error('Error generating AI reply:', error);
-      res.status(500).json({ 
+      console.error('Error generating AI reply:', error)
+      res.status(500).json({
         message: String(error),
-        success: false 
-      });
+        success: false,
+      })
     }
-  });
+  })
   // Instagram webhook endpoint
-  app.get("/webhook/instagram", async (req, res) => {
+  app.get('/webhook/instagram', async (req, res) => {
     // Webhook verification (required by Facebook)
-    const mode = req.query["hub.mode"];
-    const token = req.query["hub.verify_token"];
-    const challenge = req.query["hub.challenge"];
-    
+    const mode = req.query['hub.mode']
+    const token = req.query['hub.verify_token']
+    const challenge = req.query['hub.challenge']
+
     // Verify with token from environment or settings
-    const settings = await storage.getSettings(1); // For MVP, assume user ID 1
-    const verifyToken = process.env.INSTAGRAM_VERIFY_TOKEN || settings.apiKeys?.instagramAppId || "social_ai_avatar";
-    
+    const settings = await storage.getSettings(1) // For MVP, assume user ID 1
+    const verifyToken =
+      process.env.INSTAGRAM_VERIFY_TOKEN ||
+      settings.apiKeys?.instagramAppId ||
+      'social_ai_avatar'
+
     // Facebook requires this verification step
-    if (mode === "subscribe" && token === verifyToken) {
-      log("Instagram webhook verified");
-      res.status(200).send(challenge);
+    if (mode === 'subscribe' && token === verifyToken) {
+      log('Instagram webhook verified')
+      res.status(200).send(challenge)
     } else {
-      console.error("Instagram webhook verification failed");
-      res.status(403).json({ message: "Verification failed" });
+      console.error('Instagram webhook verification failed')
+      res.status(403).json({ message: 'Verification failed' })
     }
-  });
-  
+  })
+
   // Instagram webhook POST endpoint to receive DM notifications
-  app.post("/webhook/instagram", async (req, res) => {
+  app.post('/webhook/instagram', async (req, res) => {
     try {
-      log(`Received Instagram webhook: ${JSON.stringify(req.body, null, 2)}`);
-      
+      log(`Received Instagram webhook: ${JSON.stringify(req.body, null, 2)}`)
+
       // Respond to Facebook/Instagram immediately (required)
-      res.status(200).send("EVENT_RECEIVED");
-      
-      const data = req.body;
-      
+      res.status(200).send('EVENT_RECEIVED')
+
+      const data = req.body
+
       // Verify this is a page/Instagram message event
       if (data.object === 'instagram' || data.object === 'page') {
         // Process each entry (could be multiple in one webhook call)
@@ -837,47 +886,48 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
                   id: messagingEvent.message.mid,
                   from: {
                     id: messagingEvent.sender.id,
-                    username: "instagram_user", // In production, use Profile API to get real username
-                    profile_pic_url: undefined
+                    username: 'instagram_user', // In production, use Profile API to get real username
+                    profile_pic_url: undefined,
                   },
                   message: messagingEvent.message.text,
-                  timestamp: messagingEvent.timestamp
-                };
-                
+                  timestamp: messagingEvent.timestamp,
+                }
+
                 // Process and store the message
                 const { message: savedMessage, thread } =
-                  await instagramService.processNewMessage(instagramMessage, 1);
-                
+                  await instagramService.processNewMessage(instagramMessage, 1)
+
                 // Check if auto-reply is enabled
-                const settings = await storage.getSettings(1);
-                const aiSettings = settings.aiSettings as any;
+                const settings = await storage.getSettings(1)
+                const aiSettings = settings.aiSettings as any
 
                 if (aiSettings?.autoReplyInstagram && thread.autoReply) {
                   // Generate AI reply
                   const aiReply = await aiService.generateReply({
                     content: instagramMessage.message,
                     senderName: instagramMessage.from.username,
-                    creatorToneDescription: aiSettings.creatorToneDescription || "",
+                    creatorToneDescription:
+                      aiSettings.creatorToneDescription || '',
                     temperature: (aiSettings.temperature || 70) / 100,
                     maxLength: aiSettings.maxResponseLength || 500,
-                    model: aiSettings.model || "gpt-4o",
-                    flexProcessing: aiSettings.flexProcessing || false
-                  });
-                  
+                    model: aiSettings.model || 'gpt-4o',
+                    flexProcessing: aiSettings.flexProcessing || false,
+                  })
+
                   // Send reply to Instagram
-                  const delaySec = aiSettings.responseDelay || 0;
+                  const delaySec = aiSettings.responseDelay || 0
                   if (delaySec > 0) {
-                    await new Promise((r) => setTimeout(r, delaySec * 1000));
+                    await new Promise((r) => setTimeout(r, delaySec * 1000))
                   }
-                  await instagramService.sendReply(instagramMessage.id, aiReply);
-                  
+                  await instagramService.sendReply(instagramMessage.id, aiReply)
+
                   // Update message status
                   await storage.updateMessageStatus(
-                    savedMessage.id, 
-                    "auto-replied", 
-                    aiReply, 
-                    true
-                  );
+                    savedMessage.id,
+                    'auto-replied',
+                    aiReply,
+                    true,
+                  )
                 }
               }
             }
@@ -885,249 +935,249 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
         }
       }
     } catch (error: any) {
-      console.error("Error processing Instagram webhook:", error.message);
+      console.error('Error processing Instagram webhook:', error.message)
       // We've already sent 200 OK to Facebook, so we're just logging the error here
     }
-  });
-  
+  })
+
   // Instagram DM endpoints
-  app.get("/api/instagram/messages", async (req, res) => {
+  app.get('/api/instagram/messages', async (req, res) => {
     try {
       // First fetch existing messages
-      let messages = await storage.getInstagramMessages();
-      
+      let messages = await storage.getInstagramMessages()
+
       // If we have fewer than 5 messages, generate some new ones
       if (messages.length < 5) {
         // Generate 1-3 new messages
-        await instagramService.fetchMessages(1);
-        
-        // Get the updated messages list
-        messages = await storage.getInstagramMessages();
-      }
-      
-      res.json(messages);
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
+        await instagramService.fetchMessages(1)
 
-  app.post("/api/instagram/reply", async (req, res) => {
+        // Get the updated messages list
+        messages = await storage.getInstagramMessages()
+      }
+
+      res.json(messages)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.post('/api/instagram/reply', async (req, res) => {
     try {
       const schema = z.object({
         messageId: z.number(),
         reply: z.string().min(1),
-      });
-      
-      const { messageId, reply } = schema.parse(req.body);
-      const message = await storage.getMessage(messageId);
-      
-      if (!message) {
-        return res.status(404).json({ message: "Message not found" });
-      }
-      
-      await instagramService.sendReply(message.externalId, reply);
-      
-      const updatedMessage = await storage.updateMessageStatus(
-        messageId, 
-        "replied", 
-        reply, 
-        false
-      );
-      
-      res.json(updatedMessage);
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
+      })
 
-  app.post("/api/instagram/ai-reply", async (req, res) => {
-    try {
-      const schema = z.object({ 
-        messageId: z.number(),
-        useContext: z.boolean().optional().default(false)
-      });
-      const { messageId, useContext } = schema.parse(req.body);
-      
-      const message = await storage.getMessage(messageId);
+      const { messageId, reply } = schema.parse(req.body)
+      const message = await storage.getMessage(messageId)
+
       if (!message) {
-        return res.status(404).json({ message: "Message not found" });
+        return res.status(404).json({ message: 'Message not found' })
       }
-      
-      const settings = await storage.getSettings(1); // For MVP, assume user ID 1
-      
+
+      await instagramService.sendReply(message.externalId, reply)
+
+      const updatedMessage = await storage.updateMessageStatus(
+        messageId,
+        'replied',
+        reply,
+        false,
+      )
+
+      res.json(updatedMessage)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.post('/api/instagram/ai-reply', async (req, res) => {
+    try {
+      const schema = z.object({
+        messageId: z.number(),
+        useContext: z.boolean().optional().default(false),
+      })
+      const { messageId, useContext } = schema.parse(req.body)
+
+      const message = await storage.getMessage(messageId)
+      if (!message) {
+        return res.status(404).json({ message: 'Message not found' })
+      }
+
+      const settings = await storage.getSettings(1) // For MVP, assume user ID 1
+
       // Get context snippets for RAG pipeline if requested
-      let contextSnippets: string[] = [];
-      
+      let contextSnippets: string[] = []
+
       if (useContext) {
         // In our MVP, we'll use simple hard-coded context snippets about the creator
         // In production, these would come from the creator's content database
         contextSnippets = [
-          "I prefer warm, vibrant colors for my tropical destination content.",
-          "My editing style focuses on storytelling first, with technical aspects being secondary.",
-          "I recommend the Sony A7IV with 24-70mm lens for most content creators.",
-          "I use Adobe Premiere Pro for video editing and Lightroom for photos.",
-          "My favorite travel destinations include Bali, Japan, and Costa Rica."
-        ];
+          'I prefer warm, vibrant colors for my tropical destination content.',
+          'My editing style focuses on storytelling first, with technical aspects being secondary.',
+          'I recommend the Sony A7IV with 24-70mm lens for most content creators.',
+          'I use Adobe Premiere Pro for video editing and Lightroom for photos.',
+          'My favorite travel destinations include Bali, Japan, and Costa Rica.',
+        ]
       }
-      
+
       // Generate AI reply with context from RAG pipeline
-      let aiReply;
+      let aiReply
       try {
         aiReply = await aiService.generateReply({
           content: message.content,
           senderName: message.senderName,
-          creatorToneDescription: settings.creatorToneDescription || "",
+          creatorToneDescription: settings.creatorToneDescription || '',
           temperature: (settings.aiTemperature || 70) / 100, // Default to 0.7 if null
           maxLength: settings.maxResponseLength || 500, // Default to 500 if null,
           contextSnippets: useContext ? contextSnippets : undefined,
-          model: settings.aiSettings?.model || "gpt-4o",
-          flexProcessing: settings.aiSettings?.flexProcessing || false
-        });
+          model: settings.aiSettings?.model || 'gpt-4o',
+          flexProcessing: settings.aiSettings?.flexProcessing || false,
+        })
       } catch (aiError: any) {
-        console.error("Error generating AI reply:", aiError.message);
-        return res.status(500).json({ 
+        console.error('Error generating AI reply:', aiError.message)
+        return res.status(500).json({
           message: `Failed to generate AI reply: ${aiError.message}`,
-          fallback: true
-        });
+          fallback: true,
+        })
       }
-      
+
       // Send reply to Instagram (in a real app, this would use the actual Instagram API)
       try {
-        const delaySec = settings.aiSettings?.responseDelay || 0;
+        const delaySec = settings.aiSettings?.responseDelay || 0
         if (delaySec > 0) {
-          await new Promise((r) => setTimeout(r, delaySec * 1000));
+          await new Promise((r) => setTimeout(r, delaySec * 1000))
         }
-        await instagramService.sendReply(message.externalId, aiReply);
+        await instagramService.sendReply(message.externalId, aiReply)
       } catch (instagramError) {
-        log("Note: Instagram reply simulation - would fail in production app");
+        log('Note: Instagram reply simulation - would fail in production app')
         // In development, we'll continue even if this fails
       }
-      
+
       // Update message status
       const updatedMessage = await storage.updateMessageStatus(
-        messageId, 
-        "auto-replied", 
-        aiReply, 
-        true
-      );
-      
-      res.json(updatedMessage);
-    } catch (error: any) {
-      console.error("Error handling AI reply request:", error);
-      res.status(500).json({ message: error.message });
-    }
-  });
-  
-  // YouTube comment endpoints
-  app.get("/api/youtube/messages", async (req, res) => {
-    try {
-      const messages = await storage.getYoutubeMessages();
-      res.json(messages);
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
+        messageId,
+        'auto-replied',
+        aiReply,
+        true,
+      )
 
-  app.post("/api/youtube/reply", async (req, res) => {
+      res.json(updatedMessage)
+    } catch (error: any) {
+      console.error('Error handling AI reply request:', error)
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  // YouTube comment endpoints
+  app.get('/api/youtube/messages', async (req, res) => {
+    try {
+      const messages = await storage.getYoutubeMessages()
+      res.json(messages)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.post('/api/youtube/reply', async (req, res) => {
     try {
       const schema = z.object({
         messageId: z.number(),
         reply: z.string().min(1),
-      });
-      
-      const { messageId, reply } = schema.parse(req.body);
-      const message = await storage.getMessage(messageId);
-      
-      if (!message) {
-        return res.status(404).json({ message: "Message not found" });
-      }
-      
-      await youtubeService.sendReply(message.externalId, reply);
-      
-      const updatedMessage = await storage.updateMessageStatus(
-        messageId, 
-        "replied", 
-        reply, 
-        false
-      );
-      
-      res.json(updatedMessage);
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
+      })
 
-  app.post("/api/youtube/ai-reply", async (req, res) => {
-    try {
-      const schema = z.object({ messageId: z.number() });
-      const { messageId } = schema.parse(req.body);
-      
-      const message = await storage.getMessage(messageId);
+      const { messageId, reply } = schema.parse(req.body)
+      const message = await storage.getMessage(messageId)
+
       if (!message) {
-        return res.status(404).json({ message: "Message not found" });
+        return res.status(404).json({ message: 'Message not found' })
       }
-      
-      const settings = await storage.getSettings(1); // For MVP, assume user ID 1
-      
+
+      await youtubeService.sendReply(message.externalId, reply)
+
+      const updatedMessage = await storage.updateMessageStatus(
+        messageId,
+        'replied',
+        reply,
+        false,
+      )
+
+      res.json(updatedMessage)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.post('/api/youtube/ai-reply', async (req, res) => {
+    try {
+      const schema = z.object({ messageId: z.number() })
+      const { messageId } = schema.parse(req.body)
+
+      const message = await storage.getMessage(messageId)
+      if (!message) {
+        return res.status(404).json({ message: 'Message not found' })
+      }
+
+      const settings = await storage.getSettings(1) // For MVP, assume user ID 1
+
       // Generate AI reply
       const aiReply = await aiService.generateReply({
         content: message.content,
         senderName: message.senderName,
-        creatorToneDescription: settings.creatorToneDescription || "",
+        creatorToneDescription: settings.creatorToneDescription || '',
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 500,
-        model: settings.aiSettings?.model || "gpt-4o",
+        model: settings.aiSettings?.model || 'gpt-4o',
         flexProcessing: settings.aiSettings?.flexProcessing || false,
-      });
-      
+      })
+
       // Send reply to YouTube
-      const delaySec = settings.aiSettings?.responseDelay || 0;
+      const delaySec = settings.aiSettings?.responseDelay || 0
       if (delaySec > 0) {
-        await new Promise((r) => setTimeout(r, delaySec * 1000));
+        await new Promise((r) => setTimeout(r, delaySec * 1000))
       }
-      await youtubeService.sendReply(message.externalId, aiReply);
-      
+      await youtubeService.sendReply(message.externalId, aiReply)
+
       // Update message status
       const updatedMessage = await storage.updateMessageStatus(
-        messageId, 
-        "auto-replied", 
-        aiReply, 
-        true
-      );
-      
-      res.json(updatedMessage);
+        messageId,
+        'auto-replied',
+        aiReply,
+        true,
+      )
+
+      res.json(updatedMessage)
     } catch (error: any) {
-      res.status(500).json({ message: error.message });
+      res.status(500).json({ message: error.message })
     }
-  });
-  
+  })
+
   // AI endpoints
-  app.post("/api/ai/generate-reply", async (req, res) => {
+  app.post('/api/ai/generate-reply', async (req, res) => {
     try {
       const schema = z.object({
         content: z.string(),
         senderName: z.string(),
-        source: z.enum(["instagram", "youtube"]),
+        source: z.enum(['instagram', 'youtube']),
         messageId: z.number().optional(),
         useContext: z.boolean().optional(),
-      });
-      
-      const data = schema.parse(req.body);
-      const settings = await storage.getSettings(1); // For MVP, assume user ID 1
-      
+      })
+
+      const data = schema.parse(req.body)
+      const settings = await storage.getSettings(1) // For MVP, assume user ID 1
+
       // Get relevant content snippets if context is requested
-        let contextSnippets: string[] = [];
+      let contextSnippets: string[] = []
       if (data.useContext) {
         // In production, these would come from contentService.retrieveRelevantContent
         // For MVP demo, we'll use sample content that mimics what would come from the RAG pipeline
         contextSnippets = [
-          "I always tell creators to focus on authentic storytelling rather than chasing trends",
-          "My ideal camera setup is the Sony A7IV with a 24-70mm lens for travel content",
-          "When editing, I prefer to maintain natural colors with slight vibrance enhancement",
-          "I believe consistency is more important than frequency when it comes to content creation",
-          "My content creation philosophy centers on providing value first, monetization second"
-        ];
-        
+          'I always tell creators to focus on authentic storytelling rather than chasing trends',
+          'My ideal camera setup is the Sony A7IV with a 24-70mm lens for travel content',
+          'When editing, I prefer to maintain natural colors with slight vibrance enhancement',
+          'I believe consistency is more important than frequency when it comes to content creation',
+          'My content creation philosophy centers on providing value first, monetization second',
+        ]
+
         // For real implementation:
         // try {
         //   contextSnippets = await contentService.retrieveRelevantContent(
@@ -1140,76 +1190,77 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
         //   // Continue without context if retrieval fails
         // }
       }
-      
+
       const reply = await aiService.generateReply({
         content: data.content,
         senderName: data.senderName,
-        creatorToneDescription: settings.creatorToneDescription || "",
+        creatorToneDescription: settings.creatorToneDescription || '',
         temperature: (settings.aiTemperature || 70) / 100, // Default to 0.7 if null
         maxLength: settings.maxResponseLength || 500, // Default to 500 if null,
-        contextSnippets: contextSnippets.length > 0 ? contextSnippets : undefined,
-        model: settings.aiSettings?.model || "gpt-4o",
-        flexProcessing: settings.aiSettings?.flexProcessing || false
-      });
-      
-      res.json({ reply: reply });
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
+        contextSnippets:
+          contextSnippets.length > 0 ? contextSnippets : undefined,
+        model: settings.aiSettings?.model || 'gpt-4o',
+        flexProcessing: settings.aiSettings?.flexProcessing || false,
+      })
 
-  app.post("/api/ai/classify-intent", async (req, res) => {
-    try {
-      const schema = z.object({ text: z.string() });
-      const { text } = schema.parse(req.body);
-      
-      const classification = await aiService.classifyIntent(text);
-      res.json(classification);
+      res.json({ reply: reply })
     } catch (error: any) {
-      res.status(500).json({ message: error.message });
+      res.status(500).json({ message: error.message })
     }
-  });
+  })
 
-  app.post("/api/ai/detect-sensitive", async (req, res) => {
+  app.post('/api/ai/classify-intent', async (req, res) => {
     try {
-      const schema = z.object({ text: z.string() });
-      const { text } = schema.parse(req.body);
-      
-      const detection = await aiService.detectSensitiveContent(text);
-      res.json(detection);
+      const schema = z.object({ text: z.string() })
+      const { text } = schema.parse(req.body)
+
+      const classification = await aiService.classifyIntent(text)
+      res.json(classification)
     } catch (error: any) {
-      res.status(500).json({ message: error.message });
+      res.status(500).json({ message: error.message })
     }
-  });
-  
+  })
+
+  app.post('/api/ai/detect-sensitive', async (req, res) => {
+    try {
+      const schema = z.object({ text: z.string() })
+      const { text } = schema.parse(req.body)
+
+      const detection = await aiService.detectSensitiveContent(text)
+      res.json(detection)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
   // Airtable lead capture
-  app.post("/api/airtable/lead", async (req, res) => {
+  app.post('/api/airtable/lead', async (req, res) => {
     try {
       const schema = z.object({
         messageId: z.number(),
-        source: z.enum(["instagram", "youtube"]),
-      });
-      
-      const { messageId, source } = schema.parse(req.body);
-      const message = await storage.getMessage(messageId);
-      
+        source: z.enum(['instagram', 'youtube']),
+      })
+
+      const { messageId, source } = schema.parse(req.body)
+      const message = await storage.getMessage(messageId)
+
       if (!message) {
-        return res.status(404).json({ message: "Message not found" });
+        return res.status(404).json({ message: 'Message not found' })
       }
-      
-      const settings = await storage.getSettings(1);
-      
+
+      const settings = await storage.getSettings(1)
+
       // Add to Airtable
       const recordId = await airtableService.addLead({
         name: message.senderName,
         message: message.content,
         source,
-        contactInfo: "", // In a real app, extract from message if available
-        intentCategory: message.intentCategory || "Interest",
-        baseId: settings.airtableBaseId || "",
-        tableName: settings.airtableTableName || "Leads",
-      });
-      
+        contactInfo: '', // In a real app, extract from message if available
+        intentCategory: message.intentCategory || 'Interest',
+        baseId: settings.airtableBaseId || '',
+        tableName: settings.airtableTableName || 'Leads',
+      })
+
       // Store lead in database
       const lead = await storage.createLead({
         messageId,
@@ -1217,81 +1268,84 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
         name: message.senderName,
         source,
         intentCategory: message.intentCategory,
-        contactInfo: "",
+        contactInfo: '',
         notes: message.content,
         airtableRecordId: recordId,
-        status: "new",
-      });
-      
-      res.json({ success: true, lead });
+        status: 'new',
+      })
+
+      res.json({ success: true, lead })
     } catch (error: any) {
-      res.status(500).json({ message: error.message });
+      res.status(500).json({ message: error.message })
     }
-  });
-  
+  })
+
   // Instagram webhook setup endpoint
-  app.post("/api/instagram/setup-webhook", async (req, res) => {
+  app.post('/api/instagram/setup-webhook', async (req, res) => {
     try {
       // Use the dynamic protocol and host for webhook URL
-      const baseUrl = process.env.WEBHOOK_BASE_URL || `${req.protocol}://${req.get('host')}`;
-      const webhookUrl = `${baseUrl}/webhook/instagram`;
-      
+      const baseUrl =
+        process.env.WEBHOOK_BASE_URL || `${req.protocol}://${req.get('host')}`
+      const webhookUrl = `${baseUrl}/webhook/instagram`
+
       // Pass the user ID (using ID 1 for now) to the webhook setup
-      const result = await instagramService.setupWebhook(webhookUrl, 1);
-      
+      const result = await instagramService.setupWebhook(webhookUrl, 1)
+
       if (result.success) {
         // Start polling immediately to fetch any existing messages
-        await instagramService.fetchMessages(1);
+        await instagramService.fetchMessages(1)
       }
-      
-      res.json(result);
+
+      res.json(result)
     } catch (error: any) {
-      res.status(500).json({ message: error.message });
+      res.status(500).json({ message: error.message })
     }
-  });
-  
+  })
+
   // Fetch new Instagram messages manually (polling)
-  app.post("/api/instagram/poll", async (req, res) => {
+  app.post('/api/instagram/poll', async (req, res) => {
     try {
-      const result = await instagramService.fetchMessages(1);
-      res.json(result);
+      const result = await instagramService.fetchMessages(1)
+      res.json(result)
     } catch (error: any) {
-      res.status(500).json({ message: error.message });
+      res.status(500).json({ message: error.message })
     }
-  });
-  
+  })
+
   // Instagram OAuth callback endpoint - receives the code from Instagram
-  app.get("/api/instagram/callback", async (req, res) => {
+  app.get('/api/instagram/callback', async (req, res) => {
     try {
-      const code = req.query.code as string;
-      
+      const code = req.query.code as string
+
       if (!code) {
-        console.error("No authorization code received from Instagram");
-        return res.redirect("/?error=instagram_auth_failed&message=No%20authorization%20code%20received");
+        console.error('No authorization code received from Instagram')
+        return res.redirect(
+          '/?error=instagram_auth_failed&message=No%20authorization%20code%20received',
+        )
       }
-      
-      log("Received Instagram authorization code");
-      
+
+      log('Received Instagram authorization code')
+
       // For now, we'll use user ID 1 (will be dynamic with real user system)
-      const userId = 1;
-      
+      const userId = 1
+
       // Use the OAuth service to exchange code for token
-      const redirectUri = `${req.protocol}://${req.get('host')}/api/instagram/callback`;
-      const instagramAppId = process.env.INSTAGRAM_APP_ID || "";
-      const instagramAppSecret = process.env.INSTAGRAM_APP_SECRET || "";
-      
+      const redirectUri = `${req.protocol}://${req.get('host')}/api/instagram/callback`
+      const instagramAppId = process.env.INSTAGRAM_APP_ID || ''
+      const instagramAppSecret = process.env.INSTAGRAM_APP_SECRET || ''
+
       // Complete the auth flow (exchange code, get long-lived token, get profile)
       const result = await oauthService.completeInstagramAuth(
         code,
         redirectUri,
         instagramAppId,
         instagramAppSecret,
-        userId
-      );
-      
+        userId,
+      )
+
       if (result) {
-        log("Instagram authentication completed successfully");
-        
+        log('Instagram authentication completed successfully')
+
         // Close the popup and redirect to Instagram page
         const html = `
           <html>
@@ -1303,340 +1357,392 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
               <p>Authentication successful! You can close this window.</p>
             </body>
           </html>
-        `;
-        
-        return res.send(html);
+        `
+
+        return res.send(html)
       } else {
-        return res.redirect("/?error=instagram_auth_failed");
+        return res.redirect('/?error=instagram_auth_failed')
       }
     } catch (error: any) {
-      console.error("Error in Instagram callback:", error.message);
-      return res.redirect("/?error=instagram_auth_failed&message=" + encodeURIComponent(error.message));
+      console.error('Error in Instagram callback:', error.message)
+      return res.redirect(
+        '/?error=instagram_auth_failed&message=' +
+          encodeURIComponent(error.message),
+      )
     }
-  });
-  
+  })
+
   // Instagram OAuth client-side initiation endpoint
-  app.post("/api/instagram/auth", async (req, res) => {
+  app.post('/api/instagram/auth', async (req, res) => {
     try {
       const schema = z.object({
         code: z.string(),
         redirectUri: z.string().url(),
         clientId: z.string(),
         clientSecret: z.string(),
-      });
-      
-      const { code, redirectUri, clientId, clientSecret } = schema.parse(req.body);
-      
+      })
+
+      const { code, redirectUri, clientId, clientSecret } = schema.parse(
+        req.body,
+      )
+
       // Complete the OAuth flow
       const result = await oauthService.completeInstagramAuth(
         code,
         redirectUri,
         clientId,
         clientSecret,
-        1 // For MVP, assume user ID 1
-      );
-      
-      res.json(result);
+        1, // For MVP, assume user ID 1
+      )
+
+      res.json(result)
     } catch (error: any) {
-      console.error('Instagram auth error:', error.message);
-      res.status(500).json({ message: error.message });
+      console.error('Instagram auth error:', error.message)
+      res.status(500).json({ message: error.message })
     }
-  });
+  })
 
   // Settings endpoints
-  app.get("/api/settings", async (req, res) => {
+  app.get('/api/settings', async (req, res) => {
     try {
-      const settings = await storage.getSettings(1); // For MVP, assume user ID 1
-      
+      const settings = await storage.getSettings(1) // For MVP, assume user ID 1
+
       // Initialize default values for new JSON properties if they don't exist
       if (!settings.apiKeys) {
         settings.apiKeys = {
-          instagram: settings.instagramToken || "",
-          instagramAppId: "",
-          instagramAppSecret: "",
-          instagramUserId: "",
-          instagramPageId: "",
-          instagramWebhookUrl: "",
-          youtube: settings.youtubeToken || "",
-          openai: settings.openaiToken || "",
-          airtable: settings.airtableToken || "",
-          airtableBaseId: settings.airtableBaseId || "",
-          airtableTableName: settings.airtableTableName || "Leads"
-        };
+          instagram: settings.instagramToken || '',
+          instagramAppId: '',
+          instagramAppSecret: '',
+          instagramUserId: '',
+          instagramPageId: '',
+          instagramWebhookUrl: '',
+          youtube: settings.youtubeToken || '',
+          openai: settings.openaiToken || '',
+          airtable: settings.airtableToken || '',
+          airtableBaseId: settings.airtableBaseId || '',
+          airtableTableName: settings.airtableTableName || 'Leads',
+        }
       }
-      
+
       if (!settings.aiSettings) {
         settings.aiSettings = {
-          temperature: settings.aiTemperature ? settings.aiTemperature / 100 : 0.7,
-          creatorToneDescription: settings.creatorToneDescription || "",
+          temperature: settings.aiTemperature
+            ? settings.aiTemperature / 100
+            : 0.7,
+          creatorToneDescription: settings.creatorToneDescription || '',
           maxResponseLength: settings.maxResponseLength || 500,
-          model: settings.aiModel || "gpt-4o",
+          model: settings.aiModel || 'gpt-4o',
           autoReplyInstagram: settings.aiAutoRepliesInstagram || false,
           autoReplyYoutube: settings.aiAutoRepliesYoutube || false,
           flexProcessing: false,
-          responseDelay: 0
-        };
+          responseDelay: 0,
+        }
       }
-      
+
       if (!settings.notificationSettings) {
         settings.notificationSettings = {
-          email: settings.notificationEmail || "",
+          email: settings.notificationEmail || '',
           notifyOnHighIntent: settings.notifyOnHighIntent || true,
-          notifyOnSensitiveTopics: settings.notifyOnSensitiveTopics || true
-        };
+          notifyOnSensitiveTopics: settings.notifyOnSensitiveTopics || true,
+        }
       }
-      
-      res.json(settings);
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
 
-  app.post("/api/settings", async (req, res) => {
+      res.json(settings)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.post('/api/settings', async (req, res) => {
     try {
       const schema = z.object({
-        apiKeys: z.object({
-          instagram: z.string().optional(),
-          instagramAppId: z.string().optional(),
-          instagramAppSecret: z.string().optional(),
-          instagramUserId: z.string().optional(),
-          instagramPageId: z.string().optional(),
-          instagramWebhookUrl: z.string().optional(),
-          youtube: z.string().optional(),
-          openai: z.string().optional(),
-          airtable: z.string().optional(),
-          airtableBaseId: z.string().optional(),
-          airtableTableName: z.string().optional(),
-        }).optional(),
-        aiSettings: z.object({
-          temperature: z.number().min(0).max(1).optional(),
-          creatorToneDescription: z.string().optional(),
-          maxResponseLength: z.number().min(50).max(2000).optional(),
-          model: z.string().optional(),
-          autoReplyInstagram: z.boolean().optional(),
-          autoReplyYoutube: z.boolean().optional(),
-          flexProcessing: z.boolean().optional(),
-          responseDelay: z.number().min(0).optional(),
-        }).optional(),
-        notificationSettings: z.object({
-          email: z.string().email().optional(),
-          notifyOnHighIntent: z.boolean().optional(),
-          notifyOnSensitiveTopics: z.boolean().optional(),
-        }).optional(),
-      });
-      
-      const data = schema.parse(req.body);
-      const userId = 1; // For MVP, assume user ID 1
-      
+        apiKeys: z
+          .object({
+            instagram: z.string().optional(),
+            instagramAppId: z.string().optional(),
+            instagramAppSecret: z.string().optional(),
+            instagramUserId: z.string().optional(),
+            instagramPageId: z.string().optional(),
+            instagramWebhookUrl: z.string().optional(),
+            youtube: z.string().optional(),
+            openai: z.string().optional(),
+            airtable: z.string().optional(),
+            airtableBaseId: z.string().optional(),
+            airtableTableName: z.string().optional(),
+          })
+          .optional(),
+        aiSettings: z
+          .object({
+            temperature: z.number().min(0).max(1).optional(),
+            creatorToneDescription: z.string().optional(),
+            maxResponseLength: z.number().min(50).max(2000).optional(),
+            model: z.string().optional(),
+            autoReplyInstagram: z.boolean().optional(),
+            autoReplyYoutube: z.boolean().optional(),
+            flexProcessing: z.boolean().optional(),
+            responseDelay: z.number().min(0).optional(),
+          })
+          .optional(),
+        notificationSettings: z
+          .object({
+            email: z.string().email().optional(),
+            notifyOnHighIntent: z.boolean().optional(),
+            notifyOnSensitiveTopics: z.boolean().optional(),
+          })
+          .optional(),
+      })
+
+      const data = schema.parse(req.body)
+      const userId = 1 // For MVP, assume user ID 1
+
       // Get existing settings
-      const existingSettings = await storage.getSettings(userId);
-      let updates: any = {};
-      
+      const existingSettings = await storage.getSettings(userId)
+      let updates: any = {}
+
       // Handle both new JSON fields and legacy fields for backward compatibility
       if (data.apiKeys) {
         // Update JSON fields
         updates.apiKeys = {
           ...(existingSettings.apiKeys as any),
-          ...(data.apiKeys as any)
-        };
-        
+          ...(data.apiKeys as any),
+        }
+
         // Also update legacy fields for backward compatibility
         if (data.apiKeys.instagram !== undefined) {
-          updates.instagramToken = data.apiKeys.instagram;
+          updates.instagramToken = data.apiKeys.instagram
         }
         if (data.apiKeys.youtube !== undefined) {
-          updates.youtubeToken = data.apiKeys.youtube;
+          updates.youtubeToken = data.apiKeys.youtube
         }
         if (data.apiKeys.openai !== undefined) {
-          updates.openaiToken = data.apiKeys.openai;
+          updates.openaiToken = data.apiKeys.openai
           log(
             data.apiKeys.openai
               ? 'OpenAI API key saved via settings.'
-              : 'OpenAI API key cleared via settings.'
-          );
+              : 'OpenAI API key cleared via settings.',
+          )
         }
         if (data.apiKeys.airtable !== undefined) {
-          updates.airtableToken = data.apiKeys.airtable;
+          updates.airtableToken = data.apiKeys.airtable
         }
         if (data.apiKeys.airtableBaseId !== undefined) {
-          updates.airtableBaseId = data.apiKeys.airtableBaseId;
+          updates.airtableBaseId = data.apiKeys.airtableBaseId
         }
         if (data.apiKeys.airtableTableName !== undefined) {
-          updates.airtableTableName = data.apiKeys.airtableTableName;
+          updates.airtableTableName = data.apiKeys.airtableTableName
         }
       }
-      
+
       if (data.aiSettings) {
         // Update JSON field
         updates.aiSettings = {
           ...(existingSettings.aiSettings as any),
-          ...(data.aiSettings as any)
-        };
-        
+          ...(data.aiSettings as any),
+        }
+
         // Also update legacy fields for backward compatibility
         if (data.aiSettings.temperature !== undefined) {
-          updates.aiTemperature = Math.round(data.aiSettings.temperature * 100);
+          updates.aiTemperature = Math.round(data.aiSettings.temperature * 100)
         }
         if (data.aiSettings.creatorToneDescription !== undefined) {
-          updates.creatorToneDescription = data.aiSettings.creatorToneDescription;
+          updates.creatorToneDescription =
+            data.aiSettings.creatorToneDescription
         }
         if (data.aiSettings.maxResponseLength !== undefined) {
-          updates.maxResponseLength = data.aiSettings.maxResponseLength;
+          updates.maxResponseLength = data.aiSettings.maxResponseLength
         }
         if (data.aiSettings.model !== undefined) {
-          updates.aiModel = data.aiSettings.model;
+          updates.aiModel = data.aiSettings.model
         }
         if (data.aiSettings.autoReplyInstagram !== undefined) {
-          updates.aiAutoRepliesInstagram = data.aiSettings.autoReplyInstagram;
+          updates.aiAutoRepliesInstagram = data.aiSettings.autoReplyInstagram
         }
         if (data.aiSettings.autoReplyYoutube !== undefined) {
-          updates.aiAutoRepliesYoutube = data.aiSettings.autoReplyYoutube;
+          updates.aiAutoRepliesYoutube = data.aiSettings.autoReplyYoutube
         }
       }
-      
+
       if (data.notificationSettings) {
         // Update JSON field
         updates.notificationSettings = {
           ...(existingSettings.notificationSettings as any),
-          ...(data.notificationSettings as any)
-        };
-        
+          ...(data.notificationSettings as any),
+        }
+
         // Also update legacy fields for backward compatibility
         if (data.notificationSettings.email !== undefined) {
-          updates.notificationEmail = data.notificationSettings.email;
+          updates.notificationEmail = data.notificationSettings.email
         }
         if (data.notificationSettings.notifyOnHighIntent !== undefined) {
-          updates.notifyOnHighIntent = data.notificationSettings.notifyOnHighIntent;
+          updates.notifyOnHighIntent =
+            data.notificationSettings.notifyOnHighIntent
         }
         if (data.notificationSettings.notifyOnSensitiveTopics !== undefined) {
-          updates.notifyOnSensitiveTopics = data.notificationSettings.notifyOnSensitiveTopics;
+          updates.notifyOnSensitiveTopics =
+            data.notificationSettings.notifyOnSensitiveTopics
         }
       }
-      
-      const updatedSettings = await storage.updateSettings(userId, updates);
-      res.json({ success: true, settings: updatedSettings });
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
 
-  app.post("/api/settings/ai-auto-replies", async (req, res) => {
+      const updatedSettings = await storage.updateSettings(userId, updates)
+      res.json({ success: true, settings: updatedSettings })
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.post('/api/settings/ai-auto-replies', async (req, res) => {
     try {
-      log(`API Request received: /api/settings/ai-auto-replies ${JSON.stringify(req.body)}`);
-      
+      log(
+        `API Request received: /api/settings/ai-auto-replies ${JSON.stringify(req.body)}`,
+      )
+
       const schema = z.object({
         enabled: z.boolean(),
-        source: z.enum(["instagram", "youtube"]),
-      });
-      
-      const { enabled, source } = schema.parse(req.body);
-      const userId = 1; // For MVP, assume user ID 1
-      
-      log(`Updating ${source} auto-replies to: ${enabled}`);
-      
+        source: z.enum(['instagram', 'youtube']),
+      })
+
+      const { enabled, source } = schema.parse(req.body)
+      const userId = 1 // For MVP, assume user ID 1
+
+      log(`Updating ${source} auto-replies to: ${enabled}`)
+
       // First get existing settings
-      const existingSettings = await storage.getSettings(userId);
-      log(`Current settings: ${JSON.stringify(existingSettings)}`);
-      
-      let updates: any = {};
-      if (source === "instagram") {
+      const existingSettings = await storage.getSettings(userId)
+      log(`Current settings: ${JSON.stringify(existingSettings)}`)
+
+      let updates: any = {}
+      if (source === 'instagram') {
         // Force a boolean value to avoid null or undefined issues
-        updates.aiAutoRepliesInstagram = Boolean(enabled);
-        
+        updates.aiAutoRepliesInstagram = Boolean(enabled)
+
         // Also update the nested JSON field if it exists
         if (existingSettings.aiSettings) {
           updates.aiSettings = {
             ...existingSettings.aiSettings,
-            autoReplyInstagram: Boolean(enabled)
-          };
+            autoReplyInstagram: Boolean(enabled),
+          }
         } else {
           // Create aiSettings if it doesn't exist
           updates.aiSettings = {
             autoReplyInstagram: Boolean(enabled),
             autoReplyYoutube: false,
             temperature: 0.7,
-            creatorToneDescription: "",
+            creatorToneDescription: '',
             maxResponseLength: 500,
-            model: "gpt-4o"
-          };
+            model: 'gpt-4o',
+          }
         }
       } else {
         // Force a boolean value to avoid null or undefined issues
-        updates.aiAutoRepliesYoutube = Boolean(enabled);
-        
+        updates.aiAutoRepliesYoutube = Boolean(enabled)
+
         // Also update the nested JSON field if it exists
         if (existingSettings.aiSettings) {
           updates.aiSettings = {
             ...existingSettings.aiSettings,
-            autoReplyYoutube: Boolean(enabled)
-          };
+            autoReplyYoutube: Boolean(enabled),
+          }
         } else {
           // Create aiSettings if it doesn't exist
           updates.aiSettings = {
             autoReplyInstagram: false,
             autoReplyYoutube: Boolean(enabled),
             temperature: 0.7,
-            creatorToneDescription: "",
+            creatorToneDescription: '',
             maxResponseLength: 500,
-            model: "gpt-4o"
-          };
+            model: 'gpt-4o',
+          }
         }
       }
-      
-      log(`Applying updates: ${JSON.stringify(updates)}`);
-      
-      const updatedSettings = await storage.updateSettings(userId, updates);
-      log(`Settings updated successfully: ${JSON.stringify(updatedSettings)}`);
-      
-      res.json({ success: true, settings: updatedSettings });
-    } catch (error: any) {
-      console.error("Error updating AI auto-replies:", error);
-      res.status(500).json({ success: false, message: error.message });
-    }
-  });
-  
-  // Automation rules endpoints
-  app.get("/api/automation/rules", async (req, res) => {
-    try {
-      const rules = await storage.getAutomationRules(1); // For MVP, assume user ID 1
-      res.json(rules);
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
 
-  app.post("/api/automation/rules", async (req, res) => {
+      log(`Applying updates: ${JSON.stringify(updates)}`)
+
+      const updatedSettings = await storage.updateSettings(userId, updates)
+      log(`Settings updated successfully: ${JSON.stringify(updatedSettings)}`)
+
+      res.json({ success: true, settings: updatedSettings })
+    } catch (error: any) {
+      console.error('Error updating AI auto-replies:', error)
+      res.status(500).json({ success: false, message: error.message })
+    }
+  })
+
+  // Persona config endpoints
+  app.get('/api/persona', async (_req, res) => {
+    const settings = await storage.getSettings(1)
+    res.json({
+      personaConfig: settings.personaConfig,
+      systemPrompt: settings.systemPrompt,
+    })
+  })
+
+  app.post('/api/persona', async (req, res) => {
+    try {
+      const schema = z.object({
+        toneDescription: z.string().min(1),
+        styleTags: z.array(z.string()).default([]),
+        allowedTopics: z.array(z.string()).min(1),
+        restrictedTopics: z.array(z.string()).default([]),
+        fallbackReply: z.string().min(1),
+      })
+      const data = schema.parse(req.body)
+      const prompt = buildSystemPrompt(data)
+      const updated = await storage.updateSettings(1, {
+        personaConfig: data,
+        systemPrompt: prompt,
+      })
+      res.json({
+        success: true,
+        personaConfig: updated.personaConfig,
+        systemPrompt: updated.systemPrompt,
+      })
+    } catch (err: any) {
+      res.status(400).json({ message: err.message })
+    }
+  })
+
+  // Automation rules endpoints
+  app.get('/api/automation/rules', async (req, res) => {
+    try {
+      const rules = await storage.getAutomationRules(1) // For MVP, assume user ID 1
+      res.json(rules)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.post('/api/automation/rules', async (req, res) => {
     try {
       const schema = z.object({
         name: z.string().min(1),
         enabled: z.boolean().default(true),
-        triggerType: z.string().default("keywords"),
+        triggerType: z.string().default('keywords'),
         triggerKeywords: z.array(z.string()).default([]),
         action: z.string().min(1),
         responseTemplate: z.string().optional(),
-      });
-      
-      const data = schema.parse(req.body);
-      const userId = 1; // For MVP, assume user ID 1
-      
+      })
+
+      const data = schema.parse(req.body)
+      const userId = 1 // For MVP, assume user ID 1
+
       const rule = await storage.createAutomationRule({
         ...data,
         userId,
-      });
-      
-      res.json(rule);
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
+      })
 
-  app.put("/api/automation/rules/:id", async (req, res) => {
+      res.json(rule)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.put('/api/automation/rules/:id', async (req, res) => {
     try {
-      const ruleId = parseInt(req.params.id);
+      const ruleId = parseInt(req.params.id)
       if (isNaN(ruleId)) {
-        return res.status(400).json({ message: "Invalid rule ID" });
+        return res.status(400).json({ message: 'Invalid rule ID' })
       }
-      
+
       const schema = z.object({
         name: z.string().min(1),
         enabled: z.boolean(),
@@ -1644,81 +1750,90 @@ app.patch('/api/threads/:id/auto-reply', async (req, res) => {
         triggerKeywords: z.array(z.string()),
         action: z.string().min(1),
         responseTemplate: z.string().optional(),
-      });
-      
-      const data = schema.parse(req.body);
-      const updatedRule = await storage.updateAutomationRule(ruleId, data);
-      
+      })
+
+      const data = schema.parse(req.body)
+      const updatedRule = await storage.updateAutomationRule(ruleId, data)
+
       if (!updatedRule) {
-        return res.status(404).json({ message: "Rule not found" });
+        return res.status(404).json({ message: 'Rule not found' })
       }
-      
-      res.json(updatedRule);
-    } catch (error: any) {
-      res.status(500).json({ message: error.message });
-    }
-  });
 
-  app.delete("/api/automation/rules/:id", async (req, res) => {
+      res.json(updatedRule)
+    } catch (error: any) {
+      res.status(500).json({ message: error.message })
+    }
+  })
+
+  app.delete('/api/automation/rules/:id', async (req, res) => {
     try {
-      const ruleId = parseInt(req.params.id);
+      const ruleId = parseInt(req.params.id)
       if (isNaN(ruleId)) {
-        return res.status(400).json({ message: "Invalid rule ID" });
+        return res.status(400).json({ message: 'Invalid rule ID' })
       }
-      
-      const success = await storage.deleteAutomationRule(ruleId);
-      
+
+      const success = await storage.deleteAutomationRule(ruleId)
+
       if (!success) {
-        return res.status(404).json({ message: "Rule not found" });
+        return res.status(404).json({ message: 'Rule not found' })
       }
-      
-      res.json({ success: true });
+
+      res.json({ success: true })
     } catch (error: any) {
-      res.status(500).json({ message: error.message });
+      res.status(500).json({ message: error.message })
     }
-  });
+  })
 
-// See CHANGELOG.md for 2025-06-14 [Added] – Content search endpoint
-app.get('/api/content/search', async (req, res) => {
-  try {
-    const q = req.query.q;
-    if (typeof q !== 'string' || q.trim() === '') {
-      return res.status(400).json({ message: 'q is required' });
+  // See CHANGELOG.md for 2025-06-14 [Added] – Content search endpoint
+  app.get('/api/content/search', async (req, res) => {
+    try {
+      const q = req.query.q
+      if (typeof q !== 'string' || q.trim() === '') {
+        return res.status(400).json({ message: 'q is required' })
+      }
+
+      const userId = req.query.userId ? Number(req.query.userId) : 1
+      const limit = req.query.limit
+        ? parseInt(req.query.limit as string, 10)
+        : 5
+
+      const results = await contentService.retrieveRelevantContent(
+        q,
+        userId,
+        limit,
+      )
+      res.json({ results })
+    } catch (error: any) {
+      console.error('Error searching content:', error)
+      res.status(500).json({ message: 'Failed to search content' })
     }
-
-    const userId = req.query.userId ? Number(req.query.userId) : 1;
-    const limit  = req.query.limit  ? parseInt(req.query.limit as string, 10) : 5;
-
-    const results = await contentService.retrieveRelevantContent(q, userId, limit);
-    res.json({ results });
-  } catch (error: any) {
-    console.error('Error searching content:', error);
-    res.status(500).json({ message: 'Failed to search content' });
-  }
-});
+  })
 
   // Analytics endpoint
-  app.get("/api/analytics", async (req, res) => {
+  app.get('/api/analytics', async (req, res) => {
     try {
-      const analytics = await storage.getAnalytics(1); // For MVP, assume user ID 1
-      
+      const analytics = await storage.getAnalytics(1) // For MVP, assume user ID 1
+
       // Sample data for charts
-      const sevenDaysAgo = new Date();
-      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-      
-      const engagementByDay = [];
+      const sevenDaysAgo = new Date()
+      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
+
+      const engagementByDay = []
       for (let i = 0; i < 7; i++) {
-        const date = new Date();
-        date.setDate(date.getDate() - i);
-        const formattedDate = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-        
+        const date = new Date()
+        date.setDate(date.getDate() - i)
+        const formattedDate = date.toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+        })
+
         engagementByDay.unshift({
           date: formattedDate,
           instagram: Math.floor(Math.random() * 10) + 1,
           youtube: Math.floor(Math.random() * 8) + 1,
-        });
+        })
       }
-      
+
       res.json({
         messagesByPlatform: {
           instagram: analytics.instagramMsgCount,
@@ -1733,19 +1848,19 @@ app.get('/api/content/search', async (req, res) => {
         highIntentLeads: analytics.highIntentLeadsCount,
         engagementByDay,
         topTopics: analytics.topTopics || [
-          { name: "Pricing", count: 12 },
-          { name: "Features", count: 9 },
-          { name: "Support", count: 7 },
-          { name: "Collaboration", count: 5 },
-          { name: "Feedback", count: 4 },
+          { name: 'Pricing', count: 12 },
+          { name: 'Features', count: 9 },
+          { name: 'Support', count: 7 },
+          { name: 'Collaboration', count: 5 },
+          { name: 'Feedback', count: 4 },
         ],
         sensitiveTopicsCount: analytics.sensitiveTopicsCount,
-      });
+      })
     } catch (error: any) {
-      res.status(500).json({ message: error.message });
+      res.status(500).json({ message: error.message })
     }
-  });
+  })
 
-  const httpServer = createServer(app);
-  return httpServer;
+  const httpServer = createServer(app)
+  return httpServer
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5,16 +5,16 @@
 // See CHANGELOG.md for 2025-06-12 [Fixed]
 // See CHANGELOG.md for 2025-06-13 [Added-2]
 import {
-  messages, 
-  users, 
-  settings, 
-  automationRules, 
-  leads, 
+  messages,
+  users,
+  settings,
+  automationRules,
+  leads,
   analytics,
   messageThreads,
-  type User, 
-  type InsertUser, 
-  type Message, 
+  type User,
+  type InsertUser,
+  type Message,
   type InsertMessage,
   type Settings,
   type InsertSettings,
@@ -30,103 +30,121 @@ import {
   type InsertMessageThread,
   type ThreadType,
   type ContentItem,
-  type InsertContentItem
-  } from "@shared/schema";
+  type InsertContentItem,
+} from '@shared/schema'
 
 // Extend storage interface with necessary methods
 export interface IStorage {
   // User methods
-  getUser(id: number): Promise<User | undefined>;
-  getUserByUsername(username: string): Promise<User | undefined>;
-  createUser(user: InsertUser): Promise<User>;
+  getUser(id: number): Promise<User | undefined>
+  getUserByUsername(username: string): Promise<User | undefined>
+  createUser(user: InsertUser): Promise<User>
 
   // Message methods
-  getMessage(id: number): Promise<Message | undefined>;
-  getInstagramMessages(): Promise<MessageType[]>;
-  getYoutubeMessages(): Promise<MessageType[]>;
-  createMessage(message: InsertMessage): Promise<Message>;
-  updateMessageStatus(id: number, status: string, reply: string, isAiGenerated: boolean): Promise<Message>;
+  getMessage(id: number): Promise<Message | undefined>
+  getInstagramMessages(): Promise<MessageType[]>
+  getYoutubeMessages(): Promise<MessageType[]>
+  createMessage(message: InsertMessage): Promise<Message>
+  updateMessageStatus(
+    id: number,
+    status: string,
+    reply: string,
+    isAiGenerated: boolean,
+  ): Promise<Message>
 
   // Settings methods
-  getSettings(userId: number): Promise<Settings>;
-  updateSettings(userId: number, updates: Partial<Settings>): Promise<Settings>;
+  getSettings(userId: number): Promise<Settings>
+  updateSettings(userId: number, updates: Partial<Settings>): Promise<Settings>
 
   // Automation rules methods
-  getAutomationRules(userId: number): Promise<AutomationRule[]>;
-  getAutomationRule(id: number): Promise<AutomationRule | undefined>;
-  createAutomationRule(rule: InsertAutomationRule): Promise<AutomationRule>;
-  updateAutomationRule(id: number, updates: Partial<AutomationRule>): Promise<AutomationRule | undefined>;
-  deleteAutomationRule(id: number): Promise<boolean>;
+  getAutomationRules(userId: number): Promise<AutomationRule[]>
+  getAutomationRule(id: number): Promise<AutomationRule | undefined>
+  createAutomationRule(rule: InsertAutomationRule): Promise<AutomationRule>
+  updateAutomationRule(
+    id: number,
+    updates: Partial<AutomationRule>,
+  ): Promise<AutomationRule | undefined>
+  deleteAutomationRule(id: number): Promise<boolean>
 
   // Lead methods
-  getLead(id: number): Promise<Lead | undefined>;
-  getLeadsByUserId(userId: number): Promise<Lead[]>;
-  createLead(lead: InsertLead): Promise<Lead>;
-  updateLead(id: number, updates: Partial<Lead>): Promise<Lead | undefined>;
+  getLead(id: number): Promise<Lead | undefined>
+  getLeadsByUserId(userId: number): Promise<Lead[]>
+  createLead(lead: InsertLead): Promise<Lead>
+  updateLead(id: number, updates: Partial<Lead>): Promise<Lead | undefined>
 
   // Analytics methods
-  getAnalytics(userId: number): Promise<Analytics>;
-  updateAnalytics(userId: number, updates: Partial<Analytics>): Promise<Analytics>;
-  
+  getAnalytics(userId: number): Promise<Analytics>
+  updateAnalytics(
+    userId: number,
+    updates: Partial<Analytics>,
+  ): Promise<Analytics>
+
   // Content methods for RAG pipeline
-  createContentItem(contentItem: any): Promise<any>;
-  findSimilarContent(userId: number, embedding: number[], limit: number): Promise<string[]>;
-  
+  createContentItem(contentItem: any): Promise<any>
+  findSimilarContent(
+    userId: number,
+    embedding: number[],
+    limit: number,
+  ): Promise<string[]>
+
   // Thread methods for conversation continuity
-  getThread(id: number): Promise<MessageThread | undefined>;
-  getThreads(userId: number, source?: string): Promise<ThreadType[]>;
-  getThreadMessages(threadId: number): Promise<MessageType[]>;
-  createThread(thread: InsertMessageThread): Promise<MessageThread>;
-  updateThread(id: number, updates: Partial<MessageThread>): Promise<MessageThread | undefined>;
+  getThread(id: number): Promise<MessageThread | undefined>
+  getThreads(userId: number, source?: string): Promise<ThreadType[]>
+  getThreadMessages(threadId: number): Promise<MessageType[]>
+  createThread(thread: InsertMessageThread): Promise<MessageThread>
+  updateThread(
+    id: number,
+    updates: Partial<MessageThread>,
+  ): Promise<MessageThread | undefined>
   findOrCreateThreadByParticipant(
-    userId: number, 
-    externalParticipantId: string, 
-    participantName: string, 
+    userId: number,
+    externalParticipantId: string,
+    participantName: string,
     source: string,
-    participantAvatar?: string
-  ): Promise<MessageThread>;
-  addMessageToThread(threadId: number, message: InsertMessage): Promise<Message>;
-  markThreadAsRead(threadId: number): Promise<boolean>;
+    participantAvatar?: string,
+  ): Promise<MessageThread>
+  addMessageToThread(threadId: number, message: InsertMessage): Promise<Message>
+  markThreadAsRead(threadId: number): Promise<boolean>
 }
 
 export class MemStorage {
-  private users: Map<number, User>;
-  private msgs: Map<number, Message>;
-  private settingsMap: Map<number, Settings>;
-  private rules: Map<number, AutomationRule>;
-  private leadsMap: Map<number, Lead>;
-  private analyticsMap: Map<number, Analytics>;
-  private contentItems: Map<number, ContentItem>;
-  private threads: Map<number, MessageThread>;
+  private users: Map<number, User>
+  private msgs: Map<number, Message>
+  private settingsMap: Map<number, Settings>
+  private rules: Map<number, AutomationRule>
+  private leadsMap: Map<number, Lead>
+  private analyticsMap: Map<number, Analytics>
+  private contentItems: Map<number, ContentItem>
+  private threads: Map<number, MessageThread>
 
-  private userId: number;
-  private messageId: number;
-  private threadId: number;
-  private settingsId: number;
-  private ruleId: number;
-  private leadId: number;
-  private analyticsId: number;
+  private userId: number
+  private messageId: number
+  private threadId: number
+  private settingsId: number
+  private ruleId: number
+  private leadId: number
+  private analyticsId: number
 
   constructor() {
-    this.users = new Map();
-    this.msgs = new Map();
-    this.settingsMap = new Map();
-    this.rules = new Map();
-    this.leadsMap = new Map();
-    this.analyticsMap = new Map();
-    this.contentItems = new Map();
-    this.threads = new Map();
-    
-    this.userId = 1;
-    this.messageId = 1;
-    this.threadId = 1;
-    this.settingsId = 1;
-    this.ruleId = 1;
-    this.leadId = 1;
-    this.analyticsId = 1;
-    
+    this.users = new Map()
+    this.msgs = new Map()
+    this.settingsMap = new Map()
+    this.rules = new Map()
+    this.leadsMap = new Map()
+    this.analyticsMap = new Map()
+    this.contentItems = new Map()
+    this.threads = new Map()
+
+    this.userId = 1
+    this.messageId = 1
+    this.threadId = 1
+    this.settingsId = 1
+    this.ruleId = 1
+    this.leadId = 1
+    this.analyticsId = 1
+
     // Initialize with sample data for MVP
-    this.initializeSampleData();
+    this.initializeSampleData()
   }
 
   // Initialize sample data for MVP demonstration
@@ -134,12 +152,12 @@ export class MemStorage {
     // Create default user
     const defaultUser: User = {
       id: 1,
-      username: "demo_user",
-      password: "password123", // In a real app, this would be hashed
-      email: "demo@example.com",
-      createdAt: new Date()
-    };
-    this.users.set(1, defaultUser);
+      username: 'demo_user',
+      password: 'password123', // In a real app, this would be hashed
+      email: 'demo@example.com',
+      createdAt: new Date(),
+    }
+    this.users.set(1, defaultUser)
 
     // Create default settings
     const defaultSettings: Settings = {
@@ -148,23 +166,26 @@ export class MemStorage {
       apiKeys: {},
       aiSettings: { flexProcessing: false, responseDelay: 0 },
       notificationSettings: {},
+      personaConfig: null,
+      systemPrompt: null,
       aiAutoRepliesInstagram: false,
       aiAutoRepliesYoutube: false,
-      instagramToken: "",
-      youtubeToken: "",
-      openaiToken: process.env.OPENAI_API_KEY || "",
-      airtableToken: "",
-      airtableBaseId: "",
-      airtableTableName: "Leads",
-      creatorToneDescription: "Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.",
+      instagramToken: '',
+      youtubeToken: '',
+      openaiToken: process.env.OPENAI_API_KEY || '',
+      airtableToken: '',
+      airtableBaseId: '',
+      airtableTableName: 'Leads',
+      creatorToneDescription:
+        'Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.',
       aiTemperature: 70, // 0.7
-      aiModel: "gpt-4o",
+      aiModel: 'gpt-4o',
       maxResponseLength: 500,
-      notificationEmail: "demo@example.com",
+      notificationEmail: 'demo@example.com',
       notifyOnHighIntent: true,
-      notifyOnSensitiveTopics: true
-    };
-    this.settingsMap.set(1, defaultSettings);
+      notifyOnSensitiveTopics: true,
+    }
+    this.settingsMap.set(1, defaultSettings)
 
     // Create default analytics
     const defaultAnalytics: Analytics = {
@@ -179,115 +200,130 @@ export class MemStorage {
       avgResponseTimeMinutes: 15,
       highIntentLeadsCount: 2,
       topTopics: [
-        { name: "Pricing", count: 12 },
-        { name: "Features", count: 9 },
-        { name: "Support", count: 7 },
-        { name: "Collaboration", count: 5 },
-        { name: "Feedback", count: 4 }
+        { name: 'Pricing', count: 12 },
+        { name: 'Features', count: 9 },
+        { name: 'Support', count: 7 },
+        { name: 'Collaboration', count: 5 },
+        { name: 'Feedback', count: 4 },
       ],
-      sensitiveTopicsCount: 1
-    };
-    this.analyticsMap.set(1, defaultAnalytics);
+      sensitiveTopicsCount: 1,
+    }
+    this.analyticsMap.set(1, defaultAnalytics)
 
     // Add sample messages
     const sampleMessages: InsertMessage[] = [
       {
-        source: "instagram",
-        externalId: "ig-123456",
-        senderId: "user1",
-        senderName: "Michael Scott",
-        senderAvatar: "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256",
-        content: "Hey, I love your content about productivity systems! I've been struggling with managing my time. Do you offer coaching or any personalized advice?",
+        source: 'instagram',
+        externalId: 'ig-123456',
+        senderId: 'user1',
+        senderName: 'Michael Scott',
+        senderAvatar:
+          'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256',
+        content:
+          "Hey, I love your content about productivity systems! I've been struggling with managing my time. Do you offer coaching or any personalized advice?",
         timestamp: new Date(),
-        status: "new",
+        status: 'new',
         isHighIntent: true,
-        intentCategory: "service_inquiry",
+        intentCategory: 'service_inquiry',
         intentConfidence: 80,
-        userId: 1
+        userId: 1,
       },
       {
-        source: "instagram",
-        externalId: "ig-123457",
-        senderId: "user2",
-        senderName: "Jane Cooper",
-        senderAvatar: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256",
-        content: "I just watched your latest video and I have a question about the app you mentioned. What was the name again? Thanks!",
+        source: 'instagram',
+        externalId: 'ig-123457',
+        senderId: 'user2',
+        senderName: 'Jane Cooper',
+        senderAvatar:
+          'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256',
+        content:
+          'I just watched your latest video and I have a question about the app you mentioned. What was the name again? Thanks!',
         timestamp: new Date(),
-        status: "new",
+        status: 'new',
         isHighIntent: false,
-        userId: 1
+        userId: 1,
       },
       {
-        source: "instagram",
-        externalId: "ig-123458",
-        senderId: "user3",
-        senderName: "Tom Wilson",
-        senderAvatar: "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256",
-        content: "Love your content! What camera do you use for your videos?",
+        source: 'instagram',
+        externalId: 'ig-123458',
+        senderId: 'user3',
+        senderName: 'Tom Wilson',
+        senderAvatar:
+          'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256',
+        content: 'Love your content! What camera do you use for your videos?',
         timestamp: new Date(Date.now() - 86400000), // Yesterday
-        status: "auto-replied",
-        reply: "Thanks for the kind words! I use a Sony A7III for most of my videos with a 24-70mm lens. I have all my gear linked in the description of my latest video if you want to check it out. Let me know if you have any other questions!",
+        status: 'auto-replied',
+        reply:
+          'Thanks for the kind words! I use a Sony A7III for most of my videos with a 24-70mm lens. I have all my gear linked in the description of my latest video if you want to check it out. Let me know if you have any other questions!',
         isAiGenerated: true,
-        userId: 1
+        userId: 1,
       },
       {
-        source: "instagram",
-        externalId: "ig-123459",
-        senderId: "user4",
-        senderName: "Alex Morgan",
-        senderAvatar: "https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256",
-        content: "Could you do a tutorial on how to set up that productivity dashboard you showed last week?",
+        source: 'instagram',
+        externalId: 'ig-123459',
+        senderId: 'user4',
+        senderName: 'Alex Morgan',
+        senderAvatar:
+          'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256',
+        content:
+          'Could you do a tutorial on how to set up that productivity dashboard you showed last week?',
         timestamp: new Date(Date.now() - 86400000), // Yesterday
-        status: "replied",
-        reply: "Hey Alex! I'm actually planning to release a tutorial next week. I'll send you the link when it's ready!",
+        status: 'replied',
+        reply:
+          "Hey Alex! I'm actually planning to release a tutorial next week. I'll send you the link when it's ready!",
         isAiGenerated: false,
-        userId: 1
+        userId: 1,
       },
       {
-        source: "instagram",
-        externalId: "ig-123460",
-        senderId: "user5",
-        senderName: "Chris Johnson",
-        senderAvatar: "https://images.unsplash.com/photo-1539571696357-5a69c17a67c6?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256",
-        content: "I'm looking to hire someone with your expertise for my company's next project. Can we discuss potential collaboration opportunities?",
+        source: 'instagram',
+        externalId: 'ig-123460',
+        senderId: 'user5',
+        senderName: 'Chris Johnson',
+        senderAvatar:
+          'https://images.unsplash.com/photo-1539571696357-5a69c17a67c6?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256',
+        content:
+          "I'm looking to hire someone with your expertise for my company's next project. Can we discuss potential collaboration opportunities?",
         timestamp: new Date(),
-        status: "new",
+        status: 'new',
         isHighIntent: true,
-        intentCategory: "business_opportunity",
+        intentCategory: 'business_opportunity',
         intentConfidence: 90,
-        userId: 1
+        userId: 1,
       },
       {
-        source: "youtube",
-        externalId: "yt-123456",
-        senderId: "ytuser1",
-        senderName: "Sarah Williams",
-        senderAvatar: "https://images.unsplash.com/photo-1534528741775-53994a69daeb?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256",
-        content: "Great video! Do you have any tips for beginners in this field?",
+        source: 'youtube',
+        externalId: 'yt-123456',
+        senderId: 'ytuser1',
+        senderName: 'Sarah Williams',
+        senderAvatar:
+          'https://images.unsplash.com/photo-1534528741775-53994a69daeb?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256',
+        content:
+          'Great video! Do you have any tips for beginners in this field?',
         timestamp: new Date(),
-        status: "new",
-        userId: 1
+        status: 'new',
+        userId: 1,
       },
       {
-        source: "youtube",
-        externalId: "yt-123457",
-        senderId: "ytuser2",
-        senderName: "Mark Thompson",
-        senderAvatar: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256",
-        content: "I've been following your channel for months and I've learned so much. Would you consider doing a collaboration?",
+        source: 'youtube',
+        externalId: 'yt-123457',
+        senderId: 'ytuser2',
+        senderName: 'Mark Thompson',
+        senderAvatar:
+          'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=256&h=256',
+        content:
+          "I've been following your channel for months and I've learned so much. Would you consider doing a collaboration?",
         timestamp: new Date(),
-        status: "new",
+        status: 'new',
         isHighIntent: true,
-        intentCategory: "collaboration",
+        intentCategory: 'collaboration',
         intentConfidence: 85,
-        userId: 1
-      }
-    ];
+        userId: 1,
+      },
+    ]
 
-    const threadLookup = new Map<string, number>();
-    sampleMessages.forEach(msg => {
-      const key = `${msg.senderId}-${msg.source}`;
-      let tId = threadLookup.get(key);
+    const threadLookup = new Map<string, number>()
+    sampleMessages.forEach((msg) => {
+      const key = `${msg.senderId}-${msg.source}`
+      let tId = threadLookup.get(key)
       if (!tId) {
         const newThread: MessageThread = {
           id: this.threadId++,
@@ -301,129 +337,143 @@ export class MemStorage {
           status: 'active',
           unreadCount: msg.isOutbound ? 0 : 1,
           createdAt: new Date(),
-          metadata: {}
-        } as MessageThread;
-        this.threads.set(newThread.id, newThread);
-        threadLookup.set(key, newThread.id);
-        tId = newThread.id;
+          metadata: {},
+        } as MessageThread
+        this.threads.set(newThread.id, newThread)
+        threadLookup.set(key, newThread.id)
+        tId = newThread.id
       } else {
-        const existing = this.threads.get(tId)!;
-        const msgTime = msg.timestamp ?? new Date();
+        const existing = this.threads.get(tId)!
+        const msgTime = msg.timestamp ?? new Date()
         if (existing.lastMessageAt < msgTime) {
-          existing.lastMessageAt = msgTime;
-          existing.lastMessageContent = msg.content;
+          existing.lastMessageAt = msgTime
+          existing.lastMessageContent = msg.content
         }
         if (!msg.isOutbound) {
-          existing.unreadCount = (existing.unreadCount ?? 0) + 1;
+          existing.unreadCount = (existing.unreadCount ?? 0) + 1
         }
-        this.threads.set(tId, existing);
+        this.threads.set(tId, existing)
       }
 
       const message: Message = {
         ...msg,
         id: this.messageId++,
         threadId: tId,
-        timestamp: msg.timestamp ?? new Date()
-      } as Message;
-      this.msgs.set(message.id, message);
-    });
+        timestamp: msg.timestamp ?? new Date(),
+      } as Message
+      this.msgs.set(message.id, message)
+    })
 
     // Add sample automation rules
     const sampleRules: InsertAutomationRule[] = [
       {
         userId: 1,
-        name: "Reply to camera questions",
+        name: 'Reply to camera questions',
         enabled: true,
-        triggerType: "keywords",
-        triggerKeywords: ["camera", "gear", "lens", "equipment", "filming"],
-        action: "auto_reply",
-        responseTemplate: "Thanks for your interest in my gear! I use a Sony A7III with a 24-70mm lens for most of my videos. I also use the Rode VideoMic Pro+ for audio. You can find links to all my equipment in the description of my latest video."
+        triggerType: 'keywords',
+        triggerKeywords: ['camera', 'gear', 'lens', 'equipment', 'filming'],
+        action: 'auto_reply',
+        responseTemplate:
+          'Thanks for your interest in my gear! I use a Sony A7III with a 24-70mm lens for most of my videos. I also use the Rode VideoMic Pro+ for audio. You can find links to all my equipment in the description of my latest video.',
       },
       {
         userId: 1,
-        name: "Route collaboration requests to me",
+        name: 'Route collaboration requests to me',
         enabled: true,
-        triggerType: "keywords",
-        triggerKeywords: ["collab", "collaboration", "partner", "together", "joint"],
-        action: "route_human"
+        triggerType: 'keywords',
+        triggerKeywords: [
+          'collab',
+          'collaboration',
+          'partner',
+          'together',
+          'joint',
+        ],
+        action: 'route_human',
       },
       {
         userId: 1,
-        name: "Add business inquiries to Airtable",
+        name: 'Add business inquiries to Airtable',
         enabled: true,
-        triggerType: "keywords",
-        triggerKeywords: ["hire", "job", "project", "work", "business", "client"],
-        action: "add_airtable"
-      }
-    ];
+        triggerType: 'keywords',
+        triggerKeywords: [
+          'hire',
+          'job',
+          'project',
+          'work',
+          'business',
+          'client',
+        ],
+        action: 'add_airtable',
+      },
+    ]
 
-      sampleRules.forEach(rule => {
-        const automationRule: AutomationRule = {
-          ...rule,
-          id: this.ruleId++,
-          createdAt: new Date(),
-          updatedAt: new Date()
-        } as AutomationRule;
-        this.rules.set(automationRule.id, automationRule);
-      });
+    sampleRules.forEach((rule) => {
+      const automationRule: AutomationRule = {
+        ...rule,
+        id: this.ruleId++,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as AutomationRule
+      this.rules.set(automationRule.id, automationRule)
+    })
   }
 
   // User methods
   async getUser(id: number): Promise<User | undefined> {
-    return this.users.get(id);
+    return this.users.get(id)
   }
 
   async getUserByUsername(username: string): Promise<User | undefined> {
     return Array.from(this.users.values()).find(
       (user) => user.username === username,
-    );
+    )
   }
 
   async createUser(insertUser: InsertUser): Promise<User> {
-    const id = this.userId++;
-    const user: User = { ...insertUser, id, createdAt: new Date() };
-    this.users.set(id, user);
-    return user;
+    const id = this.userId++
+    const user: User = { ...insertUser, id, createdAt: new Date() }
+    this.users.set(id, user)
+    return user
   }
 
   // Message methods
   async getMessage(id: number): Promise<Message | undefined> {
-    return this.msgs.get(id);
+    return this.msgs.get(id)
   }
 
   async getInstagramMessages(): Promise<MessageType[]> {
     const instagramMessages = Array.from(this.msgs.values())
-      .filter(msg => msg.source === "instagram")
+      .filter((msg) => msg.source === 'instagram')
       .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
-      .map(msg => this.mapMessageToMessageType(msg));
-    
-    return instagramMessages;
+      .map((msg) => this.mapMessageToMessageType(msg))
+
+    return instagramMessages
   }
 
   async getYoutubeMessages(): Promise<MessageType[]> {
     const youtubeMessages = Array.from(this.msgs.values())
-      .filter(msg => msg.source === "youtube")
+      .filter((msg) => msg.source === 'youtube')
       .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
-      .map(msg => this.mapMessageToMessageType(msg));
-    
-    return youtubeMessages;
+      .map((msg) => this.mapMessageToMessageType(msg))
+
+    return youtubeMessages
   }
 
   private mapMessageToMessageType(msg: Message): MessageType {
     const sender: SenderType = {
       id: msg.senderId,
       name: msg.senderName,
-      avatar: msg.senderAvatar ?? undefined
-    };
+      avatar: msg.senderAvatar ?? undefined,
+    }
 
     // Normalize parent ID to avoid threading issues when running without the
     // database. Missing parentMessageId was causing replies to render as
     // top-level messages. Ref: [Fixed] 2025-06-08 in CHANGELOG.md
-    let parentId: number | undefined = undefined;
+    let parentId: number | undefined = undefined
     if (msg.parentMessageId !== undefined && msg.parentMessageId !== null) {
-      const numeric = Number(msg.parentMessageId);
+      const numeric = Number(msg.parentMessageId)
       if (!Number.isNaN(numeric)) {
-        parentId = numeric;
+        parentId = numeric
       }
     }
 
@@ -440,26 +490,26 @@ export class MemStorage {
       parentMessageId: parentId,
       isOutbound: msg.isOutbound || false,
       isAiGenerated: msg.isAiGenerated ?? false,
-      isAutoReply: msg.status === 'auto-replied'
-    };
+      isAutoReply: msg.status === 'auto-replied',
+    }
   }
 
   async createMessage(message: InsertMessage): Promise<Message> {
-    const id = this.messageId++;
-    const newMessage: Message = { ...message, id } as Message;
-    this.msgs.set(id, newMessage);
-    return newMessage;
+    const id = this.messageId++
+    const newMessage: Message = { ...message, id } as Message
+    this.msgs.set(id, newMessage)
+    return newMessage
   }
 
   async updateMessageStatus(
     id: number,
     status: string,
     reply: string,
-    isAiGenerated: boolean
+    isAiGenerated: boolean,
   ): Promise<Message> {
-    const message = this.msgs.get(id);
+    const message = this.msgs.get(id)
     if (!message) {
-      throw new Error(`Message with ID ${id} not found`);
+      throw new Error(`Message with ID ${id} not found`)
     }
 
     const updatedMessage: Message = {
@@ -467,27 +517,27 @@ export class MemStorage {
       status,
       reply,
       isAiGenerated,
-      replyTimestamp: new Date()
-    };
+      replyTimestamp: new Date(),
+    }
 
-    this.msgs.set(id, updatedMessage);
-    return updatedMessage;
+    this.msgs.set(id, updatedMessage)
+    return updatedMessage
   }
 
   // Thread methods for conversation continuity
   async getThread(id: number): Promise<MessageThread | undefined> {
-    return this.threads.get(id);
+    return this.threads.get(id)
   }
 
   async getThreads(userId: number, source?: string): Promise<ThreadType[]> {
-    const threads = Array.from(this.threads.values()).filter(
-      t => t.userId === userId && (!source || t.source === source)
-    ).sort((a, b) => b.lastMessageAt.getTime() - a.lastMessageAt.getTime());
+    const threads = Array.from(this.threads.values())
+      .filter((t) => t.userId === userId && (!source || t.source === source))
+      .sort((a, b) => b.lastMessageAt.getTime() - a.lastMessageAt.getTime())
 
-    return threads.map(t => {
+    return threads.map((t) => {
       const highIntent = Array.from(this.msgs.values()).some(
-        m => m.threadId === t.id && m.isHighIntent
-      );
+        (m) => m.threadId === t.id && m.isHighIntent,
+      )
       return {
         id: t.id,
         externalParticipantId: t.externalParticipantId,
@@ -499,39 +549,42 @@ export class MemStorage {
         status: t.status as 'active' | 'archived' | 'snoozed',
         unreadCount: t.unreadCount || 0,
         autoReply: t.autoReply ?? false,
-        isHighIntent: highIntent
-      };
-    });
+        isHighIntent: highIntent,
+      }
+    })
   }
 
   async getThreadMessages(threadId: number): Promise<MessageType[]> {
     return Array.from(this.msgs.values())
-      .filter(m => m.threadId === threadId)
+      .filter((m) => m.threadId === threadId)
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
-      .map(m => this.mapMessageToMessageType(m));
+      .map((m) => this.mapMessageToMessageType(m))
   }
 
   async createThread(thread: InsertMessageThread): Promise<MessageThread> {
-    const id = this.threadId++;
-    const now = new Date();
+    const id = this.threadId++
+    const now = new Date()
     const newThread: MessageThread = {
       ...thread,
       id,
       createdAt: now,
       lastMessageAt: now,
       unreadCount: 0,
-      autoReply: false
-    } as MessageThread;
-    this.threads.set(id, newThread);
-    return newThread;
+      autoReply: false,
+    } as MessageThread
+    this.threads.set(id, newThread)
+    return newThread
   }
 
-  async updateThread(id: number, updates: Partial<MessageThread>): Promise<MessageThread | undefined> {
-    const thread = this.threads.get(id);
-    if (!thread) return undefined;
-    const updated = { ...thread, ...updates } as MessageThread;
-    this.threads.set(id, updated);
-    return updated;
+  async updateThread(
+    id: number,
+    updates: Partial<MessageThread>,
+  ): Promise<MessageThread | undefined> {
+    const thread = this.threads.get(id)
+    if (!thread) return undefined
+    const updated = { ...thread, ...updates } as MessageThread
+    this.threads.set(id, updated)
+    return updated
   }
 
   async findOrCreateThreadByParticipant(
@@ -539,71 +592,82 @@ export class MemStorage {
     externalParticipantId: string,
     participantName: string,
     source: string,
-    participantAvatar?: string
+    participantAvatar?: string,
   ): Promise<MessageThread> {
     const existing = Array.from(this.threads.values()).find(
-      t => t.userId === userId &&
+      (t) =>
+        t.userId === userId &&
         t.externalParticipantId === externalParticipantId &&
-        t.source === source
-    );
-    if (existing) return existing;
+        t.source === source,
+    )
+    if (existing) return existing
     return this.createThread({
       userId,
       externalParticipantId,
       participantName,
       participantAvatar: participantAvatar || null,
       source,
-      metadata: {}
-    } as InsertMessageThread);
+      metadata: {},
+    } as InsertMessageThread)
   }
 
-  async addMessageToThread(threadId: number, message: InsertMessage): Promise<Message> {
-    const thread = this.threads.get(threadId);
+  async addMessageToThread(
+    threadId: number,
+    message: InsertMessage,
+  ): Promise<Message> {
+    const thread = this.threads.get(threadId)
     if (!thread) {
-      throw new Error(`Thread with ID ${threadId} not found`);
+      throw new Error(`Thread with ID ${threadId} not found`)
     }
-    const id = this.messageId++;
-    const now = message.timestamp ?? new Date();
-    const newMessage: Message = { ...message, id, threadId, timestamp: now } as Message;
-    this.msgs.set(id, newMessage);
+    const id = this.messageId++
+    const now = message.timestamp ?? new Date()
+    const newMessage: Message = {
+      ...message,
+      id,
+      threadId,
+      timestamp: now,
+    } as Message
+    this.msgs.set(id, newMessage)
 
     this.threads.set(threadId, {
       ...thread,
       lastMessageAt: now,
       lastMessageContent: message.content,
-      unreadCount: message.isOutbound ? thread.unreadCount : (thread.unreadCount || 0) + 1
-    });
-    return newMessage;
+      unreadCount: message.isOutbound
+        ? thread.unreadCount
+        : (thread.unreadCount || 0) + 1,
+    })
+    return newMessage
   }
 
   async markThreadAsRead(threadId: number): Promise<boolean> {
-    const thread = this.threads.get(threadId);
-    if (!thread) return false;
-    this.threads.set(threadId, { ...thread, unreadCount: 0 });
-    return true;
+    const thread = this.threads.get(threadId)
+    if (!thread) return false
+    this.threads.set(threadId, { ...thread, unreadCount: 0 })
+    return true
   }
 
   async deleteMessage(id: number): Promise<boolean> {
-    if (!this.msgs.has(id)) return false;
-    this.msgs.delete(id);
-    return true;
+    if (!this.msgs.has(id)) return false
+    this.msgs.delete(id)
+    return true
   }
 
   async deleteThread(id: number): Promise<boolean> {
-    if (!this.threads.has(id)) return false;
-    this.threads.delete(id);
+    if (!this.threads.has(id)) return false
+    this.threads.delete(id)
     for (const [mid, msg] of Array.from(this.msgs.entries())) {
       if (msg.threadId === id) {
-        this.msgs.delete(mid);
+        this.msgs.delete(mid)
       }
     }
-    return true;
+    return true
   }
 
   // Settings methods
   async getSettings(userId: number): Promise<Settings> {
-    let settings = this.settingsMap.get(userId);
-    
+    let settings = this.settingsMap.get(userId)
+
     if (!settings) {
       // Create default settings if not found
       settings = {
@@ -612,134 +676,147 @@ export class MemStorage {
         apiKeys: {},
         aiSettings: { flexProcessing: false, responseDelay: 0 },
         notificationSettings: {},
+        personaConfig: null,
+        systemPrompt: null,
         aiAutoRepliesInstagram: false,
         aiAutoRepliesYoutube: false,
-        instagramToken: "",
-        youtubeToken: "",
-        openaiToken: process.env.OPENAI_API_KEY || "",
-        airtableToken: "",
-        airtableBaseId: "",
-        airtableTableName: "Leads",
-        creatorToneDescription: "",
+        instagramToken: '',
+        youtubeToken: '',
+        openaiToken: process.env.OPENAI_API_KEY || '',
+        airtableToken: '',
+        airtableBaseId: '',
+        airtableTableName: 'Leads',
+        creatorToneDescription: '',
         aiTemperature: 70, // 0.7
-        aiModel: "gpt-4o",
+        aiModel: 'gpt-4o',
         maxResponseLength: 500,
-        notificationEmail: "",
+        notificationEmail: '',
         notifyOnHighIntent: true,
-        notifyOnSensitiveTopics: true
-      };
-      
-      this.settingsMap.set(userId, settings);
+        notifyOnSensitiveTopics: true,
+      }
+
+      this.settingsMap.set(userId, settings)
     }
-    
-    return settings;
+
+    return settings
   }
 
-  async updateSettings(userId: number, updates: Partial<Settings>): Promise<Settings> {
-    const settings = await this.getSettings(userId);
-    
+  async updateSettings(
+    userId: number,
+    updates: Partial<Settings>,
+  ): Promise<Settings> {
+    const settings = await this.getSettings(userId)
+
     const updatedSettings: Settings = {
       ...settings,
-      ...updates
-    };
-    
-    this.settingsMap.set(userId, updatedSettings);
-    return updatedSettings;
+      ...updates,
+    }
+
+    this.settingsMap.set(userId, updatedSettings)
+    return updatedSettings
   }
 
   // Automation rules methods
   async getAutomationRules(userId: number): Promise<AutomationRule[]> {
     return Array.from(this.rules.values())
-      .filter(rule => rule.userId === userId)
-      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      .filter((rule) => rule.userId === userId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
   }
 
   async getAutomationRule(id: number): Promise<AutomationRule | undefined> {
-    return this.rules.get(id);
+    return this.rules.get(id)
   }
 
-  async createAutomationRule(rule: InsertAutomationRule): Promise<AutomationRule> {
-    const id = this.ruleId++;
-    const now = new Date();
+  async createAutomationRule(
+    rule: InsertAutomationRule,
+  ): Promise<AutomationRule> {
+    const id = this.ruleId++
+    const now = new Date()
 
     const newRule: AutomationRule = {
       ...rule,
       id,
       createdAt: now,
-      updatedAt: now
-    } as AutomationRule;
-    
-    this.rules.set(id, newRule);
-    return newRule;
+      updatedAt: now,
+    } as AutomationRule
+
+    this.rules.set(id, newRule)
+    return newRule
   }
 
-  async updateAutomationRule(id: number, updates: Partial<AutomationRule>): Promise<AutomationRule | undefined> {
-    const rule = this.rules.get(id);
+  async updateAutomationRule(
+    id: number,
+    updates: Partial<AutomationRule>,
+  ): Promise<AutomationRule | undefined> {
+    const rule = this.rules.get(id)
     if (!rule) {
-      return undefined;
+      return undefined
     }
 
     const updatedRule: AutomationRule = {
       ...rule,
       ...updates,
-      updatedAt: new Date()
-    } as AutomationRule;
-    
-    this.rules.set(id, updatedRule);
-    return updatedRule;
+      updatedAt: new Date(),
+    } as AutomationRule
+
+    this.rules.set(id, updatedRule)
+    return updatedRule
   }
 
   async deleteAutomationRule(id: number): Promise<boolean> {
     if (!this.rules.has(id)) {
-      return false;
+      return false
     }
-    
-    return this.rules.delete(id);
+
+    return this.rules.delete(id)
   }
 
   // Lead methods
   async getLead(id: number): Promise<Lead | undefined> {
-    return this.leadsMap.get(id);
+    return this.leadsMap.get(id)
   }
 
   async getLeadsByUserId(userId: number): Promise<Lead[]> {
     return Array.from(this.leadsMap.values())
-      .filter(lead => lead.userId === userId)
-      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      .filter((lead) => lead.userId === userId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
   }
 
   async createLead(lead: InsertLead): Promise<Lead> {
-    const id = this.leadId++;
-    
+    const id = this.leadId++
+
     const newLead: Lead = {
       ...lead,
       id,
-      createdAt: new Date()
-    } as Lead;
-    
-    this.leadsMap.set(id, newLead);
-    return newLead;
+      createdAt: new Date(),
+    } as Lead
+
+    this.leadsMap.set(id, newLead)
+    return newLead
   }
 
-  async updateLead(id: number, updates: Partial<Lead>): Promise<Lead | undefined> {
-    const lead = this.leadsMap.get(id);
+  async updateLead(
+    id: number,
+    updates: Partial<Lead>,
+  ): Promise<Lead | undefined> {
+    const lead = this.leadsMap.get(id)
     if (!lead) {
-      return undefined;
+      return undefined
     }
-    
+
     const updatedLead: Lead = {
       ...lead,
-      ...updates
-    } as Lead;
-    
-    this.leadsMap.set(id, updatedLead);
-    return updatedLead;
+      ...updates,
+    } as Lead
+
+    this.leadsMap.set(id, updatedLead)
+    return updatedLead
   }
 
   // Analytics methods
   async getAnalytics(userId: number): Promise<Analytics> {
-    let analytics = this.analyticsMap.get(userId);
-    
+    let analytics = this.analyticsMap.get(userId)
+
     if (!analytics) {
       // Create default analytics if not found
       analytics = {
@@ -754,33 +831,38 @@ export class MemStorage {
         avgResponseTimeMinutes: 0,
         highIntentLeadsCount: 0,
         topTopics: [],
-        sensitiveTopicsCount: 0
-      };
-      
-      this.analyticsMap.set(userId, analytics);
+        sensitiveTopicsCount: 0,
+      }
+
+      this.analyticsMap.set(userId, analytics)
     }
-    
-    return analytics;
+
+    return analytics
   }
 
-  async updateAnalytics(userId: number, updates: Partial<Analytics>): Promise<Analytics> {
-    const analytics = await this.getAnalytics(userId);
+  async updateAnalytics(
+    userId: number,
+    updates: Partial<Analytics>,
+  ): Promise<Analytics> {
+    const analytics = await this.getAnalytics(userId)
 
     const updatedAnalytics: Analytics = {
       ...analytics,
-      ...updates
-    };
+      ...updates,
+    }
 
-    this.analyticsMap.set(userId, updatedAnalytics);
-    return updatedAnalytics;
+    this.analyticsMap.set(userId, updatedAnalytics)
+    return updatedAnalytics
   }
 
   // Content methods
-  async createContentItem(contentItem: InsertContentItem): Promise<ContentItem> {
-    const id = this.contentItems.size + 1;
-    const item: ContentItem = { ...contentItem, id } as ContentItem;
-    this.contentItems.set(id, item);
-    return item;
+  async createContentItem(
+    contentItem: InsertContentItem,
+  ): Promise<ContentItem> {
+    const id = this.contentItems.size + 1
+    const item: ContentItem = { ...contentItem, id } as ContentItem
+    this.contentItems.set(id, item)
+    return item
   }
 
   async findSimilarContent(
@@ -788,34 +870,33 @@ export class MemStorage {
     embedding: number[],
     limit: number,
   ): Promise<string[]> {
-
     const cosine = (a: number[], b: number[]) => {
-      let dot = 0;
-      let magA = 0;
-      let magB = 0;
+      let dot = 0
+      let magA = 0
+      let magB = 0
       for (let i = 0; i < a.length; i++) {
-        dot += a[i] * b[i];
-        magA += a[i] * a[i];
-        magB += b[i] * b[i];
+        dot += a[i] * b[i]
+        magA += a[i] * a[i]
+        magB += b[i] * b[i]
       }
-      return dot / (Math.sqrt(magA) * Math.sqrt(magB));
-    };
+      return dot / (Math.sqrt(magA) * Math.sqrt(magB))
+    }
 
     const items = Array.from(this.contentItems.values()).filter(
-      item => item.userId === userId,
-    );
+      (item) => item.userId === userId,
+    )
 
     items.sort(
       (a, b) =>
         cosine(b.embedding as number[], embedding) -
         cosine(a.embedding as number[], embedding),
-    );
+    )
 
-    return items.slice(0, limit).map(i => i.content);
+    return items.slice(0, limit).map((i) => i.content)
   }
 }
 
-import { DatabaseStorage } from "./database-storage";
+import { DatabaseStorage } from './database-storage'
 
 // Use the DatabaseStorage implementation for persistent storage
-export const storage = new DatabaseStorage();
+export const storage = new DatabaseStorage()

--- a/server/utils/prompt.ts
+++ b/server/utils/prompt.ts
@@ -1,0 +1,11 @@
+// Utility to construct system prompts from persona config
+import { AvatarPersonaConfig } from '../../client/src/types/AvatarPersonaConfig'
+
+export function buildSystemPrompt(config: AvatarPersonaConfig): string {
+  const tone = config.toneDescription.trim()
+  const allowed = config.allowedTopics.join(', ')
+  const restricted = config.restrictedTopics.join(', ')
+  const tags = config.styleTags.join(', ')
+  const fallback = config.fallbackReply.trim()
+  return `You are the creator's digital twin.\nTone: "${tone}"\nTags: ${tags}\nAllowed topics: ${allowed}\nForbidden topics: ${restricted}\nIf asked about a forbidden topic reply: "${fallback}"\nSpeak in the first person as if you are the creator and never reveal you are an AI.`
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,238 +1,296 @@
 // See CHANGELOG.md for 2025-06-12 [Added]
-import { pgTable, text, serial, integer, boolean, timestamp, jsonb, index, vector } from "drizzle-orm/pg-core";
-import { createInsertSchema } from "drizzle-zod";
-import { z } from "zod";
+import {
+  pgTable,
+  text,
+  serial,
+  integer,
+  boolean,
+  timestamp,
+  jsonb,
+  index,
+  vector,
+} from 'drizzle-orm/pg-core'
+import { createInsertSchema } from 'drizzle-zod'
+import { z } from 'zod'
 
 // Type for JSON data
-export type Json = Record<string, any>;
+export type Json = Record<string, any>
 
 // Users table
-export const users = pgTable("users", {
-  id: serial("id").primaryKey(),
-  username: text("username").notNull().unique(),
-  password: text("password").notNull(),
-  email: text("email").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  username: text('username').notNull().unique(),
+  password: text('password').notNull(),
+  email: text('email').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
 
 // Message threads table
-export const messageThreads = pgTable("message_threads", {
-  id: serial("id").primaryKey(),
-  userId: integer("user_id").references(() => users.id).notNull(),
-  externalParticipantId: text("external_participant_id").notNull(), // ID of external person (e.g. Instagram follower)
-  participantName: text("participant_name").notNull(), // Name of the person we're talking with
-  participantAvatar: text("participant_avatar"), 
-  source: text("source").notNull(), // 'instagram' or 'youtube'
-  lastMessageAt: timestamp("last_message_at").defaultNow().notNull(),
-  lastMessageContent: text("last_message_content"),
-  status: text("status").default("active"), // 'active', 'archived', 'snoozed'
-  autoReply: boolean("auto_reply").default(false),
-  unreadCount: integer("unread_count").default(0),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  metadata: jsonb("metadata"),
-});
+export const messageThreads = pgTable('message_threads', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .references(() => users.id)
+    .notNull(),
+  externalParticipantId: text('external_participant_id').notNull(), // ID of external person (e.g. Instagram follower)
+  participantName: text('participant_name').notNull(), // Name of the person we're talking with
+  participantAvatar: text('participant_avatar'),
+  source: text('source').notNull(), // 'instagram' or 'youtube'
+  lastMessageAt: timestamp('last_message_at').defaultNow().notNull(),
+  lastMessageContent: text('last_message_content'),
+  status: text('status').default('active'), // 'active', 'archived', 'snoozed'
+  autoReply: boolean('auto_reply').default(false),
+  unreadCount: integer('unread_count').default(0),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  metadata: jsonb('metadata'),
+})
 
 // Messages table (shared between Instagram and YouTube)
-export const messages = pgTable("messages", {
-  id: serial("id").primaryKey(),
-  threadId: integer("thread_id").references(() => messageThreads.id), // Link to thread
-  source: text("source").notNull(), // 'instagram' or 'youtube'
-  externalId: text("external_id").notNull(), // ID from external platform
-  senderId: text("sender_id").notNull(), // ID of sender from external platform
-  senderName: text("sender_name").notNull(),
-  senderAvatar: text("sender_avatar"),
-  content: text("content").notNull(),
-  timestamp: timestamp("timestamp").defaultNow().notNull(),
-  status: text("status").notNull().default("new"), // 'new', 'replied', 'auto-replied'
-  isHighIntent: boolean("is_high_intent").default(false),
-  intentCategory: text("intent_category"),
-  intentConfidence: integer("intent_confidence"),
-  isSensitive: boolean("is_sensitive").default(false),
-  sensitiveCategory: text("sensitive_category"),
-  reply: text("reply"),
-  replyTimestamp: timestamp("reply_timestamp"),
-  isAiGenerated: boolean("is_ai_generated").default(false),
-  isOutbound: boolean("is_outbound").default(false), // True if we sent it, false if we received it
-  parentMessageId: integer("parent_message_id"), // For tracking direct replies to specific messages
-  metadata: jsonb("metadata"),
-  userId: integer("user_id").references(() => users.id),
-});
+export const messages = pgTable('messages', {
+  id: serial('id').primaryKey(),
+  threadId: integer('thread_id').references(() => messageThreads.id), // Link to thread
+  source: text('source').notNull(), // 'instagram' or 'youtube'
+  externalId: text('external_id').notNull(), // ID from external platform
+  senderId: text('sender_id').notNull(), // ID of sender from external platform
+  senderName: text('sender_name').notNull(),
+  senderAvatar: text('sender_avatar'),
+  content: text('content').notNull(),
+  timestamp: timestamp('timestamp').defaultNow().notNull(),
+  status: text('status').notNull().default('new'), // 'new', 'replied', 'auto-replied'
+  isHighIntent: boolean('is_high_intent').default(false),
+  intentCategory: text('intent_category'),
+  intentConfidence: integer('intent_confidence'),
+  isSensitive: boolean('is_sensitive').default(false),
+  sensitiveCategory: text('sensitive_category'),
+  reply: text('reply'),
+  replyTimestamp: timestamp('reply_timestamp'),
+  isAiGenerated: boolean('is_ai_generated').default(false),
+  isOutbound: boolean('is_outbound').default(false), // True if we sent it, false if we received it
+  parentMessageId: integer('parent_message_id'), // For tracking direct replies to specific messages
+  metadata: jsonb('metadata'),
+  userId: integer('user_id').references(() => users.id),
+})
 
 // Settings table
-export const settings = pgTable("settings", {
-  id: serial("id").primaryKey(),
-  userId: integer("user_id").references(() => users.id).notNull(),
-  
+export const settings = pgTable('settings', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .references(() => users.id)
+    .notNull(),
+
   // New JSON fields for settings
-  apiKeys: jsonb("api_keys"),
-  aiSettings: jsonb("ai_settings"),
-  notificationSettings: jsonb("notification_settings"),
-  
+  apiKeys: jsonb('api_keys'),
+  aiSettings: jsonb('ai_settings'),
+  notificationSettings: jsonb('notification_settings'),
+  personaConfig: jsonb('persona_config'),
+  systemPrompt: text('system_prompt'),
+
   // Legacy fields (for backward compatibility)
-  aiAutoRepliesInstagram: boolean("ai_auto_replies_instagram").default(false),
-  aiAutoRepliesYoutube: boolean("ai_auto_replies_youtube").default(false),
-  instagramToken: text("instagram_token"),
-  youtubeToken: text("youtube_token"),
-  openaiToken: text("openai_token"),
-  airtableToken: text("airtable_token"),
-  airtableBaseId: text("airtable_base_id"),
-  airtableTableName: text("airtable_table_name"),
-  creatorToneDescription: text("creator_tone_description"),
-  aiTemperature: integer("ai_temperature").default(70), // stored as int (0.7 * 100)
-  aiModel: text("ai_model").default("gpt-4o"),
-  maxResponseLength: integer("max_response_length").default(500),
-  notificationEmail: text("notification_email"),
-  notifyOnHighIntent: boolean("notify_on_high_intent").default(true),
-  notifyOnSensitiveTopics: boolean("notify_on_sensitive_topics").default(true),
-});
+  aiAutoRepliesInstagram: boolean('ai_auto_replies_instagram').default(false),
+  aiAutoRepliesYoutube: boolean('ai_auto_replies_youtube').default(false),
+  instagramToken: text('instagram_token'),
+  youtubeToken: text('youtube_token'),
+  openaiToken: text('openai_token'),
+  airtableToken: text('airtable_token'),
+  airtableBaseId: text('airtable_base_id'),
+  airtableTableName: text('airtable_table_name'),
+  creatorToneDescription: text('creator_tone_description'),
+  aiTemperature: integer('ai_temperature').default(70), // stored as int (0.7 * 100)
+  aiModel: text('ai_model').default('gpt-4o'),
+  maxResponseLength: integer('max_response_length').default(500),
+  notificationEmail: text('notification_email'),
+  notifyOnHighIntent: boolean('notify_on_high_intent').default(true),
+  notifyOnSensitiveTopics: boolean('notify_on_sensitive_topics').default(true),
+})
 
 // Automation rules
-export const automationRules = pgTable("automation_rules", {
-  id: serial("id").primaryKey(),
-  userId: integer("user_id").references(() => users.id).notNull(),
-  name: text("name").notNull(),
-  enabled: boolean("enabled").default(true),
-  triggerType: text("trigger_type").notNull().default("keywords"), // 'keywords', 'intent', etc.
-  triggerKeywords: jsonb("trigger_keywords").default([]),
-  action: text("action").notNull(), // 'auto_reply', 'route_human', 'add_airtable'
-  responseTemplate: text("response_template"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
+export const automationRules = pgTable('automation_rules', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .references(() => users.id)
+    .notNull(),
+  name: text('name').notNull(),
+  enabled: boolean('enabled').default(true),
+  triggerType: text('trigger_type').notNull().default('keywords'), // 'keywords', 'intent', etc.
+  triggerKeywords: jsonb('trigger_keywords').default([]),
+  action: text('action').notNull(), // 'auto_reply', 'route_human', 'add_airtable'
+  responseTemplate: text('response_template'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
 
 // Lead captures
-export const leads = pgTable("leads", {
-  id: serial("id").primaryKey(),
-  messageId: integer("message_id").references(() => messages.id).notNull(),
-  userId: integer("user_id").references(() => users.id).notNull(),
-  name: text("name").notNull(),
-  source: text("source").notNull(), // 'instagram' or 'youtube'
-  intentCategory: text("intent_category"),
-  contactInfo: text("contact_info"),
-  notes: text("notes"),
-  airtableRecordId: text("airtable_record_id"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  status: text("status").default("new"), // 'new', 'contacted', 'converted', etc.
-});
+export const leads = pgTable('leads', {
+  id: serial('id').primaryKey(),
+  messageId: integer('message_id')
+    .references(() => messages.id)
+    .notNull(),
+  userId: integer('user_id')
+    .references(() => users.id)
+    .notNull(),
+  name: text('name').notNull(),
+  source: text('source').notNull(), // 'instagram' or 'youtube'
+  intentCategory: text('intent_category'),
+  contactInfo: text('contact_info'),
+  notes: text('notes'),
+  airtableRecordId: text('airtable_record_id'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  status: text('status').default('new'), // 'new', 'contacted', 'converted', etc.
+})
 
 // Analytics data
-export const analytics = pgTable("analytics", {
-  id: serial("id").primaryKey(),
-  userId: integer("user_id").references(() => users.id).notNull(),
-  date: timestamp("date").defaultNow().notNull(),
-  instagramMsgCount: integer("instagram_msg_count").default(0),
-  youtubeMsgCount: integer("youtube_msg_count").default(0),
-  newMsgCount: integer("new_msg_count").default(0),
-  repliedMsgCount: integer("replied_msg_count").default(0),
-  autoRepliedMsgCount: integer("auto_replied_msg_count").default(0),
-  avgResponseTimeMinutes: integer("avg_response_time_minutes").default(0),
-  highIntentLeadsCount: integer("high_intent_leads_count").default(0),
-  topTopics: jsonb("top_topics").default([]),
-  sensitiveTopicsCount: integer("sensitive_topics_count").default(0),
-});
+export const analytics = pgTable('analytics', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .references(() => users.id)
+    .notNull(),
+  date: timestamp('date').defaultNow().notNull(),
+  instagramMsgCount: integer('instagram_msg_count').default(0),
+  youtubeMsgCount: integer('youtube_msg_count').default(0),
+  newMsgCount: integer('new_msg_count').default(0),
+  repliedMsgCount: integer('replied_msg_count').default(0),
+  autoRepliedMsgCount: integer('auto_replied_msg_count').default(0),
+  avgResponseTimeMinutes: integer('avg_response_time_minutes').default(0),
+  highIntentLeadsCount: integer('high_intent_leads_count').default(0),
+  topTopics: jsonb('top_topics').default([]),
+  sensitiveTopicsCount: integer('sensitive_topics_count').default(0),
+})
 
 // Insert schemas
-export const insertUserSchema = createInsertSchema(users).omit({ id: true, createdAt: true });
-export const insertMessageSchema = createInsertSchema(messages).omit({ id: true });
-export const insertSettingsSchema = createInsertSchema(settings).omit({ id: true });
-export const insertAutomationRuleSchema = createInsertSchema(automationRules).omit({
-  id: true, createdAt: true, updatedAt: true
-});
-export const insertLeadSchema = createInsertSchema(leads).omit({ id: true, createdAt: true });
-export const insertAnalyticsSchema = createInsertSchema(analytics).omit({ id: true });
-export const insertMessageThreadSchema = createInsertSchema(messageThreads).omit({ 
-  id: true, createdAt: true, lastMessageAt: true 
-});
+export const insertUserSchema = createInsertSchema(users).omit({
+  id: true,
+  createdAt: true,
+})
+export const insertMessageSchema = createInsertSchema(messages).omit({
+  id: true,
+})
+export const insertSettingsSchema = createInsertSchema(settings).omit({
+  id: true,
+})
+export const insertAutomationRuleSchema = createInsertSchema(
+  automationRules,
+).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+})
+export const insertLeadSchema = createInsertSchema(leads).omit({
+  id: true,
+  createdAt: true,
+})
+export const insertAnalyticsSchema = createInsertSchema(analytics).omit({
+  id: true,
+})
+export const insertMessageThreadSchema = createInsertSchema(
+  messageThreads,
+).omit({
+  id: true,
+  createdAt: true,
+  lastMessageAt: true,
+})
 
 // Content Items table (for RAG pipeline)
-export const contentItems = pgTable("content_items", {
-  id: serial("id").primaryKey(),
-  userId: integer("user_id").references(() => users.id).notNull(),
-  externalId: text("external_id").notNull(),
-  contentType: text("content_type").notNull(), // 'post', 'video', 'blog', etc.
-  title: text("title").notNull(),
-  content: text("content").notNull(),
-  url: text("url").notNull(),
-  engagementScore: integer("engagement_score").notNull(),
-  embedding: vector("embedding", { dimensions: 1536 }), // OpenAI embeddings have 1536 dimensions
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-  metadata: jsonb("metadata").default({}),
-}, (table) => {
-  return {
-    userIdIdx: index("content_items_user_id_idx").on(table.userId),
-    contentTypeIdx: index("content_items_content_type_idx").on(table.contentType),
-    externalIdIdx: index("content_items_external_id_idx").on(table.externalId),
-  };
-});
+export const contentItems = pgTable(
+  'content_items',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    externalId: text('external_id').notNull(),
+    contentType: text('content_type').notNull(), // 'post', 'video', 'blog', etc.
+    title: text('title').notNull(),
+    content: text('content').notNull(),
+    url: text('url').notNull(),
+    engagementScore: integer('engagement_score').notNull(),
+    embedding: vector('embedding', { dimensions: 1536 }), // OpenAI embeddings have 1536 dimensions
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    metadata: jsonb('metadata').default({}),
+  },
+  (table) => {
+    return {
+      userIdIdx: index('content_items_user_id_idx').on(table.userId),
+      contentTypeIdx: index('content_items_content_type_idx').on(
+        table.contentType,
+      ),
+      externalIdIdx: index('content_items_external_id_idx').on(
+        table.externalId,
+      ),
+    }
+  },
+)
 
-export const insertContentItemSchema = createInsertSchema(contentItems).omit({ 
-  id: true, createdAt: true, updatedAt: true 
-});
+export const insertContentItemSchema = createInsertSchema(contentItems).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+})
 
 // Export types
-export type InsertUser = z.infer<typeof insertUserSchema>;
-export type User = typeof users.$inferSelect;
+export type InsertUser = z.infer<typeof insertUserSchema>
+export type User = typeof users.$inferSelect
 
-export type InsertMessage = z.infer<typeof insertMessageSchema>;
-export type Message = typeof messages.$inferSelect;
+export type InsertMessage = z.infer<typeof insertMessageSchema>
+export type Message = typeof messages.$inferSelect
 
-export type InsertSettings = z.infer<typeof insertSettingsSchema>;
+export type InsertSettings = z.infer<typeof insertSettingsSchema>
 export type Settings = typeof settings.$inferSelect & {
-  apiKeys: Record<string, any>;
-  aiSettings: Record<string, any>;
-  notificationSettings: Record<string, any>;
-};
+  apiKeys: Record<string, any>
+  aiSettings: Record<string, any>
+  notificationSettings: Record<string, any>
+  personaConfig: Record<string, any> | null
+  systemPrompt: string | null
+}
 
-export type InsertAutomationRule = z.infer<typeof insertAutomationRuleSchema>;
-export type AutomationRule = typeof automationRules.$inferSelect;
+export type InsertAutomationRule = z.infer<typeof insertAutomationRuleSchema>
+export type AutomationRule = typeof automationRules.$inferSelect
 
-export type InsertLead = z.infer<typeof insertLeadSchema>;
-export type Lead = typeof leads.$inferSelect;
+export type InsertLead = z.infer<typeof insertLeadSchema>
+export type Lead = typeof leads.$inferSelect
 
-export type InsertAnalytics = z.infer<typeof insertAnalyticsSchema>;
-export type Analytics = typeof analytics.$inferSelect;
+export type InsertAnalytics = z.infer<typeof insertAnalyticsSchema>
+export type Analytics = typeof analytics.$inferSelect
 
-export type InsertContentItem = z.infer<typeof insertContentItemSchema>;
-export type ContentItem = typeof contentItems.$inferSelect;
-export type InsertMessageThread = z.infer<typeof insertMessageThreadSchema>;
-export type MessageThread = typeof messageThreads.$inferSelect;
+export type InsertContentItem = z.infer<typeof insertContentItemSchema>
+export type ContentItem = typeof contentItems.$inferSelect
+export type InsertMessageThread = z.infer<typeof insertMessageThreadSchema>
+export type MessageThread = typeof messageThreads.$inferSelect
 
 // Message types for frontend
 export interface SenderType {
-  id: string;
-  name: string;
-  avatar?: string;
+  id: string
+  name: string
+  avatar?: string
 }
 
 export interface MessageType {
-  id: number;
-  threadId?: number;
-  source: 'instagram' | 'youtube';
-  content: string;
-  sender: SenderType;
-  timestamp: string;
-  status: 'new' | 'replied' | 'auto-replied';
-  isHighIntent: boolean;
-  reply?: string;
-  isAiGenerated?: boolean;
-  isOutbound?: boolean;
+  id: number
+  threadId?: number
+  source: 'instagram' | 'youtube'
+  content: string
+  sender: SenderType
+  timestamp: string
+  status: 'new' | 'replied' | 'auto-replied'
+  isHighIntent: boolean
+  reply?: string
+  isAiGenerated?: boolean
+  isOutbound?: boolean
   // True if the message was automatically sent by the AI system
-  isAutoReply?: boolean;
-  parentMessageId?: number;
+  isAutoReply?: boolean
+  parentMessageId?: number
 }
 
 export interface ThreadType {
-  id: number;
-  externalParticipantId: string;
-  participantName: string;
-  participantAvatar?: string;
-  source: 'instagram' | 'youtube';
-  lastMessageAt: string;
-  lastMessageContent?: string;
-  status: 'active' | 'archived' | 'snoozed';
-  unreadCount: number;
-  autoReply?: boolean;
-  isHighIntent?: boolean;
-  messages?: MessageType[];
+  id: number
+  externalParticipantId: string
+  participantName: string
+  participantAvatar?: string
+  source: 'instagram' | 'youtube'
+  lastMessageAt: string
+  lastMessageContent?: string
+  status: 'active' | 'archived' | 'snoozed'
+  unreadCount: number
+  autoReply?: boolean
+  isHighIntent?: boolean
+  messages?: MessageType[]
 }


### PR DESCRIPTION
## Summary
- add Persona page under Settings with new form
- implement prompt builder and integrate with server
- store personaConfig and systemPrompt via new API
- inject persona prompt into AI replies
- cover new routes and form with tests

## Testing
- `npm run type-check`
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684e53a9e2f08333bf04f1b78aba91d5