### PR TITLE
Fix mobile padding in conversation view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,3 +207,6 @@ CHANGLOG.md file.
 described in docs/stage_1_persona.md.
 
 2025-06-18 [Codex][Fixed] Restored mobile burger menu in ThreadedMessages.
+
+2025-06-19 [Codex][Fixed] Removed extra top padding on mobile conversation
+screen.

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -15,6 +15,7 @@
 // See CHANGELOG.md for 2025-06-12 [Fixed - mobile header visibility]
 // See CHANGELOG.md for 2025-06-14 [Added - header generate message]
 // See CHANGELOG.md for 2025-06-18 [Fixed - restore mobile burger menu]
+// See CHANGELOG.md for 2025-06-19 [Fixed - remove conversation top padding]
 import React, { useState, useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import ThreadList from '@/components/ThreadList'
@@ -349,7 +350,11 @@ const ThreadedMessages: React.FC = () => {
   }
 
   return (
-    <div className="h-full flex flex-col bg-gray-50 md:pt-0 pt-16">
+    <div
+      className={`h-full flex flex-col bg-gray-50 md:pt-0 ${
+        isMobile && showThreadList ? 'pt-16' : 'pt-0'
+      }`}
+    >
       {isMobile && showThreadList && <MobileHeader />}
       <div className="hidden md:block p-4 border-b border-gray-200 bg-white">
         <div className="flex justify-between items-center mb-4">


### PR DESCRIPTION
## Summary
- remove hard-coded top padding when showing an open thread on mobile
- document padding fix in CHANGELOG

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test -- -t dummy`

------
https://chatgpt.com/codex/tasks/task_e_684f052aa8fc8333a96aa44eec6125cf