### PR TITLE
Fix duplicate senderId in test route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,3 +214,7 @@ CHANGLOG.md file.
 - [Codex][Added] PrivacyPersonalityForm and AvatarSettingsPage.
 - [Codex][Added] buildSystemPrompt utility and persona API storage.
 - [Codex][Changed] OpenAI service uses stored systemPrompt.
+
+## 2025-06-16
+
+- [Codex][Fixed] Batch message senderId uses nanoid to avoid duplicates.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -326,7 +326,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
           })
         }
 
-        const senderId = faker.internet.userName().toLowerCase()
+        // See CHANGELOG.md for 2025-06-16 [Fixed]
+        const senderId = `${faker.internet.userName().toLowerCase()}.${faker.string.nanoid(6)}`
         const senderName = faker.person.fullName()
         const senderAvatar = faker.image.avatar()
 


### PR DESCRIPTION
## Summary
- append `nanoid` portion to batch test `senderId`
- document the fix in CHANGELOG

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm outdated`

------
https://chatgpt.com/codex/tasks/task_e_684f7d993abc83339aed0e3384c4eb84