### PR TITLE
Increase persona textarea height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,3 +220,7 @@ CHANGLOG.md file.
   desktop and mobile.
 - [Codex][Changed] Switched routing to react-router-dom.
 - [Codex][Fixed] Batch message senderId uses nanoid to avoid duplicates.
+
+## 2025-06-16
+
+- [Codex][Changed] Tone & Style textarea height increased for easier editing.

--- a/client/src/components/PrivacyPersonalityForm.tsx
+++ b/client/src/components/PrivacyPersonalityForm.tsx
@@ -1,4 +1,5 @@
 // See CHANGELOG.md for 2025-06-15 [Added]
+// See CHANGELOG.md for 2025-06-16 [Changed - deeper Tone & Style textbox]
 import React from 'react'
 import { useForm } from 'react-hook-form'
 import {
@@ -26,7 +27,11 @@ const STYLE_OPTIONS = ['Friendly', 'Professional', 'Sarcastic', 'Humorous']
 const ALLOWED_PRESETS = ['My pets', 'Content creation', 'Travel tips']
 const RESTRICTED_PRESETS = ['Politics', 'Religion', 'Personal relationships']
 
-export default function PrivacyPersonalityForm({ onSave, initialConfig, isLoading }: Props) {
+export default function PrivacyPersonalityForm({
+  onSave,
+  initialConfig,
+  isLoading,
+}: Props) {
   const form = useForm<AvatarPersonaConfig>({
     defaultValues: {
       toneDescription: initialConfig?.toneDescription || '',
@@ -71,6 +76,7 @@ export default function PrivacyPersonalityForm({ onSave, initialConfig, isLoadin
                 <Textarea
                   {...field}
                   placeholder="How should your avatar speak?"
+                  className="min-h-[240px]"
                 />
               </FormControl>
               <FormMessage />


### PR DESCRIPTION
## Summary
- make the Tone & Style textarea taller so users can enter more text
- document the change in CHANGELOG

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68500fe368108333a9c15d4f983fccce