### PR TITLE
Remove creator tone field from settings API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,4 +225,5 @@ CHANGLOG.md file.
 
 - [Codex][Fixed] System prompt preview textarea no longer stretches past page.
 - [Codex][Changed] Tone & Style textarea height increased for easier editing.
-
+- [Codex][Changed] `creatorToneDescription` removed from settings API responses
+  and validation.


### PR DESCRIPTION
## Summary
- stop returning or validating `creatorToneDescription` in settings routes
- fetch tone from root settings for internal AI replies
- document field removal in CHANGELOG

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68503167491c8333a5b4d4f63524d896