### PR TITLE
Update AIService persona tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,4 +225,4 @@ CHANGLOG.md file.
 
 - [Codex][Fixed] System prompt preview textarea no longer stretches past page.
 - [Codex][Changed] Tone & Style textarea height increased for easier editing.
-
+- [Codex][Added] AIService tests confirm personaConfig prompt handling.

--- a/server/services/openai.test.ts
+++ b/server/services/openai.test.ts
@@ -3,17 +3,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { AIService } from './openai'
 import { storage } from '../storage'
+// Persona logic covered per docs/stage_1_persona.md
+import { buildSystemPrompt } from '@shared/prompt'
 
 const openaiMock = {
   embeddings: { create: vi.fn() },
-  chat: { completions: { create: vi.fn() } }
+  chat: { completions: { create: vi.fn() } },
 }
 var openaiCtor: any
 
 vi.mock('../storage', () => ({
   storage: {
-    getSettings: vi.fn().mockResolvedValue({ openaiToken: 'stored-key' })
-  }
+    getSettings: vi.fn().mockResolvedValue({ openaiToken: 'stored-key' }),
+  },
 }))
 
 vi.mock('openai', () => {
@@ -35,7 +37,9 @@ describe('AIService', () => {
   })
 
   it('generateEmbedding returns embedding array', async () => {
-    mockEmbeddings.create.mockResolvedValueOnce({ data: [{ embedding: [1, 2, 3] }] })
+    mockEmbeddings.create.mockResolvedValueOnce({
+      data: [{ embedding: [1, 2, 3] }],
+    })
     const res = await service.generateEmbedding('text')
     expect(res).toEqual([1, 2, 3])
   })
@@ -44,45 +48,186 @@ describe('AIService', () => {
     mockEmbeddings.create.mockRejectedValueOnce(new Error('fail'))
     const res = await service.generateEmbedding('text')
     expect(res.length).toBe(1536)
-    expect(res.every(n => n === 0)).toBe(true)
+    expect(res.every((n) => n === 0)).toBe(true)
   })
 
   it('generateReply returns fallback when no api key', async () => {
     process.env.OPENAI_API_KEY = ''
     ;(storage.getSettings as any).mockResolvedValueOnce({ openaiToken: '' })
-    const reply = await service.generateReply({ content: 'hi', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, model: 'gpt-4' })
+    const reply = await service.generateReply({
+      content: 'hi',
+      senderName: 'Bob',
+      creatorToneDescription: '',
+      temperature: 0.5,
+      maxLength: 10,
+      model: 'gpt-4',
+    })
     expect(reply).toContain('Bob')
   })
 
   it('passes flex service tier when enabled', async () => {
     process.env.OPENAI_API_KEY = 'sk-valid-env-key-123456'
     ;(storage.getSettings as any).mockResolvedValueOnce({ openaiToken: '' })
-    mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] })
-    await service.generateReply({ content: 'test', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, flexProcessing: true })
-    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ service_tier: 'flex' }))
-    expect(openaiCtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'sk-valid-env-key-123456' }))
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'ok' } }],
+    })
+    await service.generateReply({
+      content: 'test',
+      senderName: 'Bob',
+      creatorToneDescription: '',
+      temperature: 0.5,
+      maxLength: 10,
+      flexProcessing: true,
+    })
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ service_tier: 'flex' }),
+    )
+    expect(openaiCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'sk-valid-env-key-123456' }),
+    )
   })
 
   it('uses provided model when making OpenAI request', async () => {
-
     process.env.OPENAI_API_KEY = 'sk-valid-env-key-123456'
     ;(storage.getSettings as any).mockResolvedValueOnce({ openaiToken: '' })
-    mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: 'ok' } }] })
-    await service.generateReply({ content: 'test', senderName: 'Bob', creatorToneDescription: '', temperature: 0.5, maxLength: 10, model: 'gpt-3.5-turbo' })
-    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-3.5-turbo' }))
-    expect(openaiCtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'sk-valid-env-key-123456' }))
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'ok' } }],
+    })
+    await service.generateReply({
+      content: 'test',
+      senderName: 'Bob',
+      creatorToneDescription: '',
+      temperature: 0.5,
+      maxLength: 10,
+      model: 'gpt-3.5-turbo',
+    })
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-3.5-turbo' }),
+    )
+    expect(openaiCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'sk-valid-env-key-123456' }),
+    )
+  })
+
+  it('builds system prompt from persona config', async () => {
+    process.env.OPENAI_API_KEY = 'sk-valid-env-key-123456'
+    const persona = {
+      toneDescription: 'zany',
+      styleTags: ['fun'],
+      allowedTopics: ['tech'],
+      restrictedTopics: ['politics'],
+      fallbackReply: 'nope',
+    }
+    ;(storage.getSettings as any).mockResolvedValueOnce({
+      openaiToken: '',
+      personaConfig: persona,
+      systemPrompt: '',
+    })
+    ;(storage.getSettings as any).mockResolvedValueOnce({
+      openaiToken: '',
+      personaConfig: persona,
+      systemPrompt: '',
+    })
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'ok' } }],
+    })
+    await service.generateReply({
+      content: 'hi',
+      senderName: 'Bob',
+      creatorToneDescription: '',
+      temperature: 0.5,
+      maxLength: 10,
+    })
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          {
+            role: 'system',
+            content: expect.stringContaining('zany'),
+          },
+          expect.any(Object),
+        ],
+      }),
+    )
+  })
+
+  it('falls back to default prompt when persona config missing', async () => {
+    process.env.OPENAI_API_KEY = 'sk-valid-env-key-123456'
+    ;(storage.getSettings as any).mockResolvedValueOnce({
+      openaiToken: '',
+      personaConfig: null,
+      systemPrompt: '',
+    })
+    ;(storage.getSettings as any).mockResolvedValueOnce({
+      openaiToken: '',
+      personaConfig: null,
+      systemPrompt: '',
+    })
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'ok' } }],
+    })
+    await service.generateReply({
+      content: 'hi',
+      senderName: 'Bob',
+      creatorToneDescription: '',
+      temperature: 0.5,
+      maxLength: 10,
+    })
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          {
+            role: 'system',
+            content: expect.any(String),
+          },
+          expect.any(Object),
+        ],
+      }),
+    )
   })
 
   it('classifyIntent parses response', async () => {
-    mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: JSON.stringify({ isHighIntent: true, confidence: 0.9, category: 'service_inquiry' }) } }] })
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              isHighIntent: true,
+              confidence: 0.9,
+              category: 'service_inquiry',
+            }),
+          },
+        },
+      ],
+    })
     const res = await service.classifyIntent('text')
-    expect(res).toEqual({ isHighIntent: true, confidence: 0.9, category: 'service_inquiry' })
+    expect(res).toEqual({
+      isHighIntent: true,
+      confidence: 0.9,
+      category: 'service_inquiry',
+    })
   })
 
   it('detectSensitiveContent parses response', async () => {
-    mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: JSON.stringify({ isSensitive: true, confidence: 0.8, category: 'legal' }) } }] })
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              isSensitive: true,
+              confidence: 0.8,
+              category: 'legal',
+            }),
+          },
+        },
+      ],
+    })
     const res = await service.detectSensitiveContent('text')
-    expect(res).toEqual({ isSensitive: true, confidence: 0.8, category: 'legal' })
+    expect(res).toEqual({
+      isSensitive: true,
+      confidence: 0.8,
+      category: 'legal',
+    })
   })
 
   it('uses stored token when env key missing', async () => {
@@ -90,7 +235,9 @@ describe('AIService', () => {
     mockEmbeddings.create.mockResolvedValueOnce({ data: [{ embedding: [4] }] })
     const res = await service.generateEmbedding('hi')
     expect(res).toEqual([4])
-    expect(openaiCtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'stored-key' }))
+    expect(openaiCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'stored-key' }),
+    )
   })
 
   it('prefers stored token over env key', async () => {
@@ -98,13 +245,15 @@ describe('AIService', () => {
     mockEmbeddings.create.mockResolvedValueOnce({ data: [{ embedding: [5] }] })
     const res = await service.generateEmbedding('hi')
     expect(res).toEqual([5])
-    expect(openaiCtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'stored-key' }))
+    expect(openaiCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'stored-key' }),
+    )
   })
 
   it('matchAutomationRules returns matching rules', async () => {
     const rules = [
       { enabled: true, triggerType: 'keywords', triggerKeywords: ['hello'] },
-      { enabled: false, triggerType: 'keywords', triggerKeywords: ['hi'] }
+      { enabled: false, triggerType: 'keywords', triggerKeywords: ['hi'] },
     ]
     const res = await service.matchAutomationRules('Say hello', rules)
     expect(res.length).toBe(1)


### PR DESCRIPTION
## Summary
- validate personaConfig-derived system prompt in AIService tests
- log changelog entry for added persona tests

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68501e3548c08333b983a33773237381