### PR TITLE
Fix id handling for message insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,4 +225,5 @@ CHANGLOG.md file.
 
 - [Codex][Fixed] System prompt preview textarea no longer stretches past page.
 - [Codex][Changed] Tone & Style textarea height increased for easier editing.
-
+- [Codex][Changed] `createMessage` and `addMessageToThread` now strip `id`
+  before insert.

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -3,12 +3,12 @@
 // See CHANGELOG.md for 2025-06-14 [Added]
 // See CHANGELOG.md for 2025-06-12 [Fixed]
 // See CHANGELOG.md for 2025-06-13 [Added-2]
-import { 
-  messages, 
-  users, 
-  settings, 
-  automationRules, 
-  leads, 
+import {
+  messages,
+  users,
+  settings,
+  automationRules,
+  leads,
   analytics,
   messageThreads,
   contentItems,
@@ -30,55 +30,66 @@ import {
   type InsertMessageThread,
   type ThreadType,
   type InsertContentItem,
-  type ContentItem
-} from "@shared/schema";
-import { db } from "./db";
-import { eq, desc, and, inArray, sql } from "drizzle-orm";
-import { IStorage } from "./storage";
-import { log } from "./logger";
+  type ContentItem,
+} from '@shared/schema'
+import { db } from './db'
+import { eq, desc, and, inArray, sql } from 'drizzle-orm'
+import { IStorage } from './storage'
+import { log } from './logger'
 
 export class DatabaseStorage implements IStorage {
   // Thread methods for conversation continuity
   async getThread(id: number): Promise<MessageThread | undefined> {
-    const [thread] = await db.select().from(messageThreads).where(eq(messageThreads.id, id));
-    return thread;
+    const [thread] = await db
+      .select()
+      .from(messageThreads)
+      .where(eq(messageThreads.id, id))
+    return thread
   }
 
   async getThreads(userId: number, source?: string): Promise<ThreadType[]> {
     let query = db
       .select()
       .from(messageThreads)
-      .where(eq(messageThreads.userId, userId));
+      .where(eq(messageThreads.userId, userId))
 
     if (source) {
       query = db
         .select()
         .from(messageThreads)
         .where(
-          and(eq(messageThreads.userId, userId), eq(messageThreads.source, source))
-        );
+          and(
+            eq(messageThreads.userId, userId),
+            eq(messageThreads.source, source),
+          ),
+        )
     }
 
     // Order by most recent message
-    const threads = await query.orderBy(desc(messageThreads.lastMessageAt));
+    const threads = await query.orderBy(desc(messageThreads.lastMessageAt))
 
-    if (threads.length === 0) return [];
+    if (threads.length === 0) return []
 
     const intentRows = await db
       .select({
         threadId: messages.threadId,
-        highIntent: sql<boolean>`bool_or(${messages.isHighIntent})`
+        highIntent: sql<boolean>`bool_or(${messages.isHighIntent})`,
       })
       .from(messages)
-      .where(inArray(messages.threadId, threads.map(t => t.id)))
-      .groupBy(messages.threadId);
+      .where(
+        inArray(
+          messages.threadId,
+          threads.map((t) => t.id),
+        ),
+      )
+      .groupBy(messages.threadId)
 
     const intentMap = new Map<number, boolean>(
-      intentRows.map(r => [r.threadId!, Boolean(r.highIntent)])
-    );
+      intentRows.map((r) => [r.threadId!, Boolean(r.highIntent)]),
+    )
 
     // Map to ThreadType
-    return threads.map(thread => ({
+    return threads.map((thread) => ({
       id: thread.id,
       externalParticipantId: thread.externalParticipantId,
       participantName: thread.participantName,
@@ -89,93 +100,96 @@ export class DatabaseStorage implements IStorage {
       status: thread.status as 'active' | 'archived' | 'snoozed',
       unreadCount: thread.unreadCount || 0,
       autoReply: thread.autoReply ?? false,
-      isHighIntent: intentMap.get(thread.id) ?? false
-    }));
+      isHighIntent: intentMap.get(thread.id) ?? false,
+    }))
   }
 
   async getThreadMessages(threadId: number): Promise<MessageType[]> {
-    log(`Fetching thread messages for thread ID ${threadId}`);
+    log(`Fetching thread messages for thread ID ${threadId}`)
 
     // Get ALL messages for the thread, including threaded conversations
     const threadMessages = await db
       .select()
       .from(messages)
       .where(eq(messages.threadId, threadId))
-      .orderBy(messages.timestamp);
+      .orderBy(messages.timestamp)
 
-    log(`Found ${threadMessages.length} messages for thread ID ${threadId}`);
+    log(`Found ${threadMessages.length} messages for thread ID ${threadId}`)
 
     // Log message details for debugging
-    const messageDetails = threadMessages.map(m => ({
+    const messageDetails = threadMessages.map((m) => ({
       id: m.id,
       content: (m.content || '').substring(0, 30),
-      parentId: m.parentMessageId, 
+      parentId: m.parentMessageId,
       threadId: m.threadId,
-      timestamp: m.timestamp
-    }));
+      timestamp: m.timestamp,
+    }))
 
-    log(`Thread messages with details: ${JSON.stringify(messageDetails)}`);
+    log(`Thread messages with details: ${JSON.stringify(messageDetails)}`)
 
     // Build parent-child relationships for debugging
-    const parentChildMap = new Map();
-    threadMessages.forEach(msg => {
+    const parentChildMap = new Map()
+    threadMessages.forEach((msg) => {
       if (msg.parentMessageId) {
         if (!parentChildMap.has(msg.parentMessageId)) {
-          parentChildMap.set(msg.parentMessageId, []);
+          parentChildMap.set(msg.parentMessageId, [])
         }
-        parentChildMap.get(msg.parentMessageId).push(msg.id);
+        parentChildMap.get(msg.parentMessageId).push(msg.id)
       }
-    });
+    })
 
     // Convert to a regular object for console logging
-    const parentChildObj: Record<number, number[]> = {};
+    const parentChildObj: Record<number, number[]> = {}
     parentChildMap.forEach((children, parentId) => {
-      parentChildObj[parentId] = children;
-    });
+      parentChildObj[parentId] = children
+    })
 
-    log(`Parent-child relationships: ${JSON.stringify(parentChildObj)}`);
+    log(`Parent-child relationships: ${JSON.stringify(parentChildObj)}`)
 
     // Map database messages to MessageType with proper parent-child relationships
-    const mappedMessages = threadMessages.map(msg => {
+    const mappedMessages = threadMessages.map((msg) => {
       // Ensure content is never undefined/null
       if (!msg.content) {
-        msg.content = `Message from ${msg.isOutbound ? 'You' : (msg.senderName || 'User')}`;
+        msg.content = `Message from ${msg.isOutbound ? 'You' : msg.senderName || 'User'}`
       }
 
       // Map to MessageType with correct parent-child relationship
-      return this.mapMessageToMessageType(msg);
-    });
+      return this.mapMessageToMessageType(msg)
+    })
 
-    return mappedMessages;
+    return mappedMessages
   }
 
   async createThread(thread: InsertMessageThread): Promise<MessageThread> {
     const [newThread] = await db
       .insert(messageThreads)
       .values(thread)
-      .returning();
+      .returning()
 
-    return newThread;
+    return newThread
   }
 
-  async updateThread(id: number, updates: Partial<MessageThread>): Promise<MessageThread | undefined> {
+  async updateThread(
+    id: number,
+    updates: Partial<MessageThread>,
+  ): Promise<MessageThread | undefined> {
     const [updatedThread] = await db
       .update(messageThreads)
       .set({
-        ...updates
+        ...updates,
       })
       .where(eq(messageThreads.id, id))
-      .returning();
+      .returning()
 
-    return updatedThread;
+    return updatedThread
   }
 
   async findOrCreateThreadByParticipant(
-    userId: number, 
-    externalParticipantId: string, 
-    participantName: string, 
+    userId: number,
+    externalParticipantId: string,
+    participantName: string,
     source: string,
-    participantAvatar?: string
+    participantAvatar?: string,
   ): Promise<MessageThread> {
     // Try to find existing thread
     const [existingThread] = await db
@@ -185,12 +199,12 @@ export class DatabaseStorage implements IStorage {
         and(
           eq(messageThreads.userId, userId),
           eq(messageThreads.externalParticipantId, externalParticipantId),
-          eq(messageThreads.source, source)
-        )
-      );
+          eq(messageThreads.source, source),
+        ),
+      )
 
     if (existingThread) {
-      return existingThread;
+      return existingThread
     }
 
     // Create new thread if one doesn't exist
@@ -205,35 +219,40 @@ export class DatabaseStorage implements IStorage {
         lastMessageAt: new Date(),
         status: 'active',
         unreadCount: 0,
-        metadata: {}
+        metadata: {},
       })
-      .returning();
+      .returning()
 
-    return newThread;
+    return newThread
   }
 
-  async addMessageToThread(threadId: number, messageData: Omit<InsertMessage, 'threadId' | 'id'>): Promise<Message> {
-    // Ensure we don't pass an 'id' field to let the database auto-generate it
-    const { id, ...cleanMessageData } = messageData as any;
+  async addMessageToThread(
+    threadId: number,
+    messageData: Omit<InsertMessage, 'id'>,
+  ): Promise<Message> {
+    const payload: any = { ...messageData }
+    delete payload.id
 
     const [newMessage] = await db
       .insert(messages)
-      .values({ ...cleanMessageData, threadId })
-      .returning();
+      .values({ ...payload, threadId })
+      .returning()
 
     // Get the thread first to properly update unread count
-    const thread = await this.getThread(threadId);
+    const thread = await this.getThread(threadId)
     if (thread) {
       // Update thread's last message information
       await this.updateThread(threadId, {
         lastMessageAt: new Date(),
         lastMessageContent: messageData.content,
         // Increment unread count if it's an inbound message
-        unreadCount: messageData.isOutbound ? thread.unreadCount : (thread.unreadCount || 0) + 1
-      });
+        unreadCount: messageData.isOutbound
+          ? thread.unreadCount
+          : (thread.unreadCount || 0) + 1,
+      })
     }
 
-    return newMessage;
+    return newMessage
   }
 
   async markThreadAsRead(threadId: number): Promise<boolean> {
@@ -243,116 +262,135 @@ export class DatabaseStorage implements IStorage {
         .set({
           unreadCount: 0,
         })
-        .where(eq(messageThreads.id, threadId));
+        .where(eq(messageThreads.id, threadId))
 
-      return true;
+      return true
     } catch (error) {
-      console.error("Error marking thread as read:", error);
-      return false;
+      console.error('Error marking thread as read:', error)
+      return false
     }
   }
 
   async deleteMessage(id: number): Promise<boolean> {
-    await db.delete(messages).where(eq(messages.id, id));
-    const [message] = await db.select().from(messages).where(eq(messages.id, id));
-    return message === undefined;
+    await db.delete(messages).where(eq(messages.id, id))
+    const [message] = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.id, id))
+    return message === undefined
   }
 
   async deleteThread(id: number): Promise<boolean> {
-    await db.delete(messages).where(eq(messages.threadId, id));
-    await db.delete(messageThreads).where(eq(messageThreads.id, id));
-    const [thread] = await db.select().from(messageThreads).where(eq(messageThreads.id, id));
-    return thread === undefined;
+    await db.delete(messages).where(eq(messages.threadId, id))
+    await db.delete(messageThreads).where(eq(messageThreads.id, id))
+    const [thread] = await db
+      .select()
+      .from(messageThreads)
+      .where(eq(messageThreads.id, id))
+    return thread === undefined
   }
 
   // Content methods for RAG pipeline
-  async createContentItem(contentItem: InsertContentItem): Promise<ContentItem> {
-    const [item] = await db
-      .insert(contentItems)
-      .values(contentItem)
-      .returning();
+  async createContentItem(
+    contentItem: InsertContentItem,
+  ): Promise<ContentItem> {
+    const [item] = await db.insert(contentItems).values(contentItem).returning()
 
-    return item;
+    return item
   }
 
-  async findSimilarContent(userId: number, embedding: number[], limit: number): Promise<string[]> {
+  async findSimilarContent(
+    userId: number,
+    embedding: number[],
+    limit: number,
+  ): Promise<string[]> {
     try {
-      const vector = `[${embedding.join(',')}]`;
+      const vector = `[${embedding.join(',')}]`
       const results = await db.execute(sql`
         SELECT content
         FROM content_items
         WHERE user_id = ${userId}
         ORDER BY embedding <-> ${sql.raw(vector)}
         LIMIT ${limit}
-      `);
-      return results.rows.map(r => r.content as string);
+      `)
+      return results.rows.map((r) => r.content as string)
     } catch (error) {
-      console.error('Error finding similar content:', error);
-      return [];
+      console.error('Error finding similar content:', error)
+      return []
     }
   }
 
   // User methods
   async getUser(id: number): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.id, id));
-    return user;
+    const [user] = await db.select().from(users).where(eq(users.id, id))
+    return user
   }
 
   async getUserByUsername(username: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.username, username));
-    return user;
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.username, username))
+    return user
   }
 
   async createUser(insertUser: InsertUser): Promise<User> {
-    const [user] = await db.insert(users).values(insertUser).returning();
-    return user;
+    const [user] = await db.insert(users).values(insertUser).returning()
+    return user
   }
 
   // Message methods
   async getMessage(id: number): Promise<Message | undefined> {
-    const [message] = await db.select().from(messages).where(eq(messages.id, id));
-    return message;
+    const [message] = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.id, id))
+    return message
   }
 
   async getInstagramMessages(): Promise<MessageType[]> {
     const instagramMessages = await db
       .select()
       .from(messages)
-      .where(eq(messages.source, "instagram"))
-      .orderBy(desc(messages.timestamp));
+      .where(eq(messages.source, 'instagram'))
+      .orderBy(desc(messages.timestamp))
 
-    return instagramMessages.map(msg => this.mapMessageToMessageType(msg));
+    return instagramMessages.map((msg) => this.mapMessageToMessageType(msg))
   }
 
   async getYoutubeMessages(): Promise<MessageType[]> {
     const youtubeMessages = await db
       .select()
       .from(messages)
-      .where(eq(messages.source, "youtube"))
-      .orderBy(desc(messages.timestamp));
+      .where(eq(messages.source, 'youtube'))
+      .orderBy(desc(messages.timestamp))
 
-    return youtubeMessages.map(msg => this.mapMessageToMessageType(msg));
+    return youtubeMessages.map((msg) => this.mapMessageToMessageType(msg))
   }
 
   private mapMessageToMessageType(msg: Message): MessageType {
     const sender: SenderType = {
       id: msg.senderId,
       name: msg.senderName,
-      avatar: msg.senderAvatar || undefined
-    };
+      avatar: msg.senderAvatar || undefined,
+    }
 
     // Process the parentMessageId carefully to properly establish threads
     // Must be a number (not a string) for the React component to handle it correctly
-    let parentId = undefined;
+    let parentId = undefined
 
     if (msg.parentMessageId !== undefined && msg.parentMessageId !== null) {
-      parentId = Number(msg.parentMessageId);
-      log(`Converting parentMessageId for message ${msg.id}: ${msg.parentMessageId} -> ${parentId}`);
+      parentId = Number(msg.parentMessageId)
+      log(
+        `Converting parentMessageId for message ${msg.id}: ${msg.parentMessageId} -> ${parentId}`,
+      )
 
       // Check if it's a valid number after conversion
       if (isNaN(parentId)) {
-        parentId = undefined;
-        log(`Invalid parentMessageId for message ${msg.id}, setting to undefined`);
+        parentId = undefined
+        log(
+          `Invalid parentMessageId for message ${msg.id}, setting to undefined`,
+        )
       }
     }
 
@@ -366,33 +404,36 @@ export class DatabaseStorage implements IStorage {
       status: msg.status as 'new' | 'replied' | 'auto-replied',
       isHighIntent: msg.isHighIntent || false,
       reply: msg.reply || undefined,
-        threadId: msg.threadId ?? undefined,
+      threadId: msg.threadId ?? undefined,
       parentMessageId: parentId,
       isOutbound: msg.isOutbound || false,
       isAiGenerated: msg.isAiGenerated || false,
-      isAutoReply: msg.status === 'auto-replied'
-    };
+      isAutoReply: msg.status === 'auto-replied',
+    }
   }
 
-  async createMessage(message: InsertMessage): Promise<Message> {
+  async createMessage(message: Omit<InsertMessage, 'id'>): Promise<Message> {
     if (process.env.DEBUG_AI) {
-      log(`[DEBUG-AI] inserting message ${JSON.stringify(message)}`);
+      log(`[DEBUG-AI] inserting message ${JSON.stringify(message)}`)
     }
 
-    const [newMessage] = await db.insert(messages).values(message).returning();
+    const payload: any = { ...message }
+    delete payload.id
+
+    const [newMessage] = await db.insert(messages).values(payload).returning()
 
     if (process.env.DEBUG_AI) {
-      log(`[DEBUG-AI] inserted message ${newMessage.id}`);
+      log(`[DEBUG-AI] inserted message ${newMessage.id}`)
     }
 
-    return newMessage;
+    return newMessage
   }
 
   async updateMessageStatus(
-    id: number, 
-    status: string, 
-    reply: string, 
-    isAiGenerated: boolean
+    id: number,
+    status: string,
+    reply: string,
+    isAiGenerated: boolean,
   ): Promise<Message> {
     const [updatedMessage] = await db
       .update(messages)
@@ -400,16 +441,16 @@ export class DatabaseStorage implements IStorage {
         status,
         reply,
         isAiGenerated,
-        replyTimestamp: new Date()
+        replyTimestamp: new Date(),
       })
       .where(eq(messages.id, id))
-      .returning();
+      .returning()
 
     if (!updatedMessage) {
-      throw new Error(`Message with ID ${id} not found`);
+      throw new Error(`Message with ID ${id} not found`)
     }
 
-    return updatedMessage;
+    return updatedMessage
   }
 
   // Settings methods
@@ -417,10 +458,10 @@ export class DatabaseStorage implements IStorage {
     const [existingSettings] = await db
       .select()
       .from(settings)
-      .where(eq(settings.userId, userId));
+      .where(eq(settings.userId, userId))
 
     if (existingSettings) {
-      return existingSettings as Settings;
+      return existingSettings as Settings
     }
 
     // Create default settings with JSON fields if not found
@@ -428,66 +469,74 @@ export class DatabaseStorage implements IStorage {
       userId,
       // JSON fields
       apiKeys: {
-        instagram: "",
-        instagramAppId: "",
-        instagramAppSecret: "",
-        instagramUserId: "",
-        instagramPageId: "",
-        instagramWebhookUrl: "",
-        youtube: "",
-        openai: process.env.OPENAI_API_KEY || "",
-        airtable: "",
-        airtableBaseId: "",
-        airtableTableName: "Leads"
+        instagram: '',
+        instagramAppId: '',
+        instagramAppSecret: '',
+        instagramUserId: '',
+        instagramPageId: '',
+        instagramWebhookUrl: '',
+        youtube: '',
+        openai: process.env.OPENAI_API_KEY || '',
+        airtable: '',
+        airtableBaseId: '',
+        airtableTableName: 'Leads',
       },
       aiSettings: {
         temperature: 0.7,
-        creatorToneDescription: "Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.",
+        creatorToneDescription:
+          'Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.',
         maxResponseLength: 500,
-        model: "gpt-4o",
+        model: 'gpt-4o',
         autoReplyInstagram: false,
         autoReplyYoutube: false,
         flexProcessing: false,
-        responseDelay: 0
+        responseDelay: 0,
       },
       notificationSettings: {
-        email: "",
+        email: '',
         notifyOnHighIntent: true,
-        notifyOnSensitiveTopics: true
+        notifyOnSensitiveTopics: true,
       },
 
       // Legacy fields (for backward compatibility)
       aiAutoRepliesInstagram: false,
       aiAutoRepliesYoutube: false,
-      instagramToken: "",
-      youtubeToken: "",
-      openaiToken: process.env.OPENAI_API_KEY || "",
-      airtableToken: "",
-      airtableBaseId: "",
-      airtableTableName: "Leads",
-      creatorToneDescription: "Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.",
+      instagramToken: '',
+      youtubeToken: '',
+      openaiToken: process.env.OPENAI_API_KEY || '',
+      airtableToken: '',
+      airtableBaseId: '',
+      airtableTableName: 'Leads',
+      creatorToneDescription:
+        'Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.',
       aiTemperature: 70, // 0.7
-      aiModel: "gpt-4o",
+      aiModel: 'gpt-4o',
       maxResponseLength: 500,
-      notificationEmail: "",
+      notificationEmail: '',
       notifyOnHighIntent: true,
-      notifyOnSensitiveTopics: true
-    };
+      notifyOnSensitiveTopics: true,
+    }
 
-      const [newSettings] = await db.insert(settings).values(defaultSettings).returning();
-      return newSettings as Settings;
+    const [newSettings] = await db
+      .insert(settings)
+      .values(defaultSettings)
+      .returning()
+    return newSettings as Settings
   }
 
-  async updateSettings(userId: number, updates: Partial<Settings>): Promise<Settings> {
-    const existingSettings = await this.getSettings(userId);
+  async updateSettings(
+    userId: number,
+    updates: Partial<Settings>,
+  ): Promise<Settings> {
+    const existingSettings = await this.getSettings(userId)
 
     const [updatedSettings] = await db
       .update(settings)
       .set(updates)
       .where(eq(settings.id, existingSettings.id))
-      .returning();
+      .returning()
 
-    return updatedSettings as Settings;
+    return updatedSettings as Settings
   }
 
   // Automation rules methods
@@ -496,58 +545,55 @@ export class DatabaseStorage implements IStorage {
       .select()
       .from(automationRules)
       .where(eq(automationRules.userId, userId))
-      .orderBy(desc(automationRules.createdAt));
+      .orderBy(desc(automationRules.createdAt))
   }
 
   async getAutomationRule(id: number): Promise<AutomationRule | undefined> {
     const [rule] = await db
       .select()
       .from(automationRules)
-      .where(eq(automationRules.id, id));
+      .where(eq(automationRules.id, id))
 
-    return rule;
+    return rule
   }
 
-  async createAutomationRule(rule: InsertAutomationRule): Promise<AutomationRule> {
-    const [newRule] = await db
-      .insert(automationRules)
-      .values(rule)
-      .returning();
+  async createAutomationRule(
+    rule: InsertAutomationRule,
+  ): Promise<AutomationRule> {
+    const [newRule] = await db.insert(automationRules).values(rule).returning()
 
-    return newRule;
+    return newRule
   }
 
-  async updateAutomationRule(id: number, updates: Partial<AutomationRule>): Promise<AutomationRule | undefined> {
+  async updateAutomationRule(
+    id: number,
+    updates: Partial<AutomationRule>,
+  ): Promise<AutomationRule | undefined> {
     const [updatedRule] = await db
       .update(automationRules)
       .set({
         ...updates,
-        updatedAt: new Date()
+        updatedAt: new Date(),
       })
       .where(eq(automationRules.id, id))
-      .returning();
+      .returning()
 
-    return updatedRule;
+    return updatedRule
   }
 
   async deleteAutomationRule(id: number): Promise<boolean> {
-    await db
-      .delete(automationRules)
-      .where(eq(automationRules.id, id));
+    await db.delete(automationRules).where(eq(automationRules.id, id))
 
     // Check if the rule still exists to determine success
-    const rule = await this.getAutomationRule(id);
-    return rule === undefined;
+    const rule = await this.getAutomationRule(id)
+    return rule === undefined
   }
 
   // Lead methods
   async getLead(id: number): Promise<Lead | undefined> {
-    const [lead] = await db
-      .select()
-      .from(leads)
-      .where(eq(leads.id, id));
+    const [lead] = await db.select().from(leads).where(eq(leads.id, id))
 
-    return lead;
+    return lead
   }
 
   async getLeadsByUserId(userId: number): Promise<Lead[]> {
@@ -555,26 +601,26 @@ export class DatabaseStorage implements IStorage {
       .select()
       .from(leads)
       .where(eq(leads.userId, userId))
-      .orderBy(desc(leads.createdAt));
+      .orderBy(desc(leads.createdAt))
   }
 
   async createLead(lead: InsertLead): Promise<Lead> {
-    const [newLead] = await db
-      .insert(leads)
-      .values(lead)
-      .returning();
+    const [newLead] = await db.insert(leads).values(lead).returning()
 
-    return newLead;
+    return newLead
   }
 
-  async updateLead(id: number, updates: Partial<Lead>): Promise<Lead | undefined> {
+  async updateLead(
+    id: number,
+    updates: Partial<Lead>,
+  ): Promise<Lead | undefined> {
     const [updatedLead] = await db
       .update(leads)
       .set(updates)
       .where(eq(leads.id, id))
-      .returning();
+      .returning()
 
-    return updatedLead;
+    return updatedLead
   }
 
   // Analytics methods
@@ -582,10 +628,10 @@ export class DatabaseStorage implements IStorage {
     const [existingAnalytics] = await db
       .select()
       .from(analytics)
-      .where(eq(analytics.userId, userId));
+      .where(eq(analytics.userId, userId))
 
     if (existingAnalytics) {
-      return existingAnalytics;
+      return existingAnalytics
     }
 
     // Create default analytics if not found
@@ -600,32 +646,35 @@ export class DatabaseStorage implements IStorage {
       avgResponseTimeMinutes: 0,
       highIntentLeadsCount: 0,
       topTopics: [
-        { name: "Pricing", count: 0 },
-        { name: "Features", count: 0 },
-        { name: "Support", count: 0 },
-        { name: "Collaboration", count: 0 },
-        { name: "Feedback", count: 0 }
+        { name: 'Pricing', count: 0 },
+        { name: 'Features', count: 0 },
+        { name: 'Support', count: 0 },
+        { name: 'Collaboration', count: 0 },
+        { name: 'Feedback', count: 0 },
       ],
-      sensitiveTopicsCount: 0
-    };
+      sensitiveTopicsCount: 0,
+    }
 
     const [newAnalytics] = await db
       .insert(analytics)
       .values(defaultAnalytics)
-      .returning();
+      .returning()
 
-    return newAnalytics;
+    return newAnalytics
   }
 
-  async updateAnalytics(userId: number, updates: Partial<Analytics>): Promise<Analytics> {
-    const existingAnalytics = await this.getAnalytics(userId);
+  async updateAnalytics(
+    userId: number,
+    updates: Partial<Analytics>,
+  ): Promise<Analytics> {
+    const existingAnalytics = await this.getAnalytics(userId)
 
     const [updatedAnalytics] = await db
       .update(analytics)
       .set(updates)
       .where(eq(analytics.id, existingAnalytics.id))
-      .returning();
+      .returning()
 
-    return updatedAnalytics;
+    return updatedAnalytics
   }
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -44,7 +44,7 @@ export interface IStorage {
   getMessage(id: number): Promise<Message | undefined>
   getInstagramMessages(): Promise<MessageType[]>
   getYoutubeMessages(): Promise<MessageType[]>
-  createMessage(message: InsertMessage): Promise<Message>
+  createMessage(message: Omit<InsertMessage, 'id'>): Promise<Message>
   updateMessageStatus(
     id: number,
     status: string,
@@ -103,7 +103,10 @@ export interface IStorage {
     source: string,
     participantAvatar?: string,
   ): Promise<MessageThread>
-  addMessageToThread(threadId: number, message: InsertMessage): Promise<Message>
+  addMessageToThread(
+    threadId: number,
+    message: Omit<InsertMessage, 'id'>,
+  ): Promise<Message>
   markThreadAsRead(threadId: number): Promise<boolean>
 }
 
@@ -500,9 +503,11 @@ export class MemStorage {
     }
   }
 
-  async createMessage(message: InsertMessage): Promise<Message> {
+  async createMessage(message: Omit<InsertMessage, 'id'>): Promise<Message> {
+    const payload: any = { ...message }
+    delete payload.id
     const id = this.messageId++
-    const newMessage: Message = { ...message, id } as Message
+    const newMessage: Message = { ...payload, id } as Message
     this.msgs.set(id, newMessage)
     return newMessage
   }
@@ -619,16 +624,18 @@ export class MemStorage {
 
   async addMessageToThread(
     threadId: number,
-    message: InsertMessage,
+    message: Omit<InsertMessage, 'id'>,
   ): Promise<Message> {
     const thread = this.threads.get(threadId)
     if (!thread) {
       throw new Error(`Thread with ID ${threadId} not found`)
     }
+    const payload: any = { ...message }
+    delete payload.id
     const id = this.messageId++
-    const now = message.timestamp ?? new Date()
+    const now = payload.timestamp ?? new Date()
     const newMessage: Message = {
-      ...message,
+      ...payload,
       id,
       threadId,
       timestamp: now,


### PR DESCRIPTION
## Summary
- enforce removing `id` before creating messages
- update storage interface to accept payloads without `id`
- note change in changelog

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685014661ae483338aee8a0f44b4d69e