### PR TITLE
Update admin tool docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,5 +232,6 @@ CHANGLOG.md file.
 - [Codex][Changed] `creatorToneDescription` removed from settings API responses
   and validation.
 - [Codex][Added] AIService tests confirm personaConfig prompt handling.
-- - [Codex][Changed] `createMessage` and `addMessageToThread` now strip `id`
+- [Codex][Changed] `createMessage` and `addMessageToThread` now strip `id`
   before insert.
+- [Codex][Docs] Explained thread prerequisites in README.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ everyone.
 
 Open the **Testing Tools** page from the sidebar when running the dev server.
 Use **Generate Batch Messages** to create 10 demo messages (at least three
-flagged high intent). Use **Generate For Thread** to add a fake incoming message
-to a specific thread ID. The Tools dropdown has returned to the Messages page
-header for quick access, but the dedicated Testing Tools page remains available.
+flagged high intent). **Generate For Thread** injects a fake incoming message
+for an existing thread—threads must already exist before using it. Create
+threads with scripts like `scripts/create-thread-test.ts` or by using **Generate
+Batch Messages**. Check `/api/threads` to view existing thread IDs. The Tools
+dropdown has returned to the Messages page header for quick access, but the
+dedicated Testing Tools page remains available.
 
 ## Continuous Integration
 


### PR DESCRIPTION
## Summary
- clarify 'Generate For Thread' usage in README
- fix stray bullet in changelog

## Testing
- `npm run type-check` *(fails: creatorToneDescription no longer exists)*
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68504e985e648333b459c51756d5a9ff