### PR TITLE
Replace creatorToneDescription with personaConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,7 +233,9 @@ CHANGLOG.md file.
   and validation.
 - [Codex][Added] AIService tests confirm personaConfig prompt handling.
 - [Codex][Changed] `createMessage` and `addMessageToThread` now strip `id`
-    before insert.
+  before insert.
 - [Codex][Added] DEBUG_AI log before custom message fetch in `ThreadedMessages`.
 - [Codex][Docs] Explained thread prerequisites in README.
 
+- [Codex][Changed-2] Replaced creatorToneDescription with personaConfig across
+  codebase.

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -3,6 +3,7 @@
 // See CHANGELOG.md for 2025-06-14 [Added]
 // See CHANGELOG.md for 2025-06-12 [Fixed]
 // See CHANGELOG.md for 2025-06-13 [Added-2]
+// See CHANGELOG.md for 2025-06-16 [Changed-2]
 import {
   messages,
   users,
@@ -236,7 +237,9 @@ export class DatabaseStorage implements IStorage {
 
       // Log the data being inserted for debugging
       if (process.env.DEBUG_AI) {
-        log(`[DEBUG-AI] Adding message to thread ${threadId}: ${JSON.stringify(cleanMessageData)}`)
+        log(
+          `[DEBUG-AI] Adding message to thread ${threadId}: ${JSON.stringify(cleanMessageData)}`,
+        )
       }
 
       const [newMessage] = await db
@@ -490,14 +493,20 @@ export class DatabaseStorage implements IStorage {
       },
       aiSettings: {
         temperature: 0.7,
-        creatorToneDescription:
-          'Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.',
         maxResponseLength: 500,
         model: 'gpt-4o',
         autoReplyInstagram: false,
         autoReplyYoutube: false,
         flexProcessing: false,
         responseDelay: 0,
+      },
+      personaConfig: {
+        toneDescription:
+          'Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.',
+        styleTags: [],
+        allowedTopics: [],
+        restrictedTopics: [],
+        fallbackReply: 'Sorry, I cannot discuss that topic.',
       },
       notificationSettings: {
         email: '',
@@ -514,8 +523,6 @@ export class DatabaseStorage implements IStorage {
       airtableToken: '',
       airtableBaseId: '',
       airtableTableName: 'Leads',
-      creatorToneDescription:
-        'Friendly, helpful, and professional. I use emojis occasionally and aim to provide valuable information in a conversational tone.',
       aiTemperature: 70, // 0.7
       aiModel: 'gpt-4o',
       maxResponseLength: 500,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,7 @@
 // See CHANGELOG.md for 2025-06-13 [Added-2]
 // See CHANGELOG.md for 2025-06-12 [Changed-2]
 // See CHANGELOG.md for 2025-06-17 [Changed]
+// See CHANGELOG.md for 2025-06-16 [Changed-2]
 import type { Express } from 'express'
 import { faker } from '@faker-js/faker'
 import { createServer, type Server } from 'http'
@@ -29,6 +30,7 @@ import { youtubeService } from './services/youtube'
 import { airtableService } from './services/airtable'
 import { aiService } from './services/openai'
 import { contentService } from './services/content'
+import type { AvatarPersonaConfig } from '@/types/AvatarPersonaConfig'
 import { oauthService } from './services/oauth'
 import { log } from './logger'
 
@@ -681,8 +683,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const generatedReply = await aiService.generateReply({
         content: messages[messages.length - 1]?.content ?? '',
         senderName: thread.participantName,
-        creatorToneDescription:
-          (settings.aiSettings as any)?.creatorToneDescription || '',
+        personaConfig:
+          settings.personaConfig as unknown as AvatarPersonaConfig | null,
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 300,
         model: settings.aiSettings?.model || 'gpt-4o',
@@ -822,9 +824,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const aiReply = await aiService.generateReply({
         content: message.content,
         senderName: message.senderName,
-        creatorToneDescription:
-          (settings.aiSettings as any)?.creatorToneDescription ||
-          'Friendly and professional',
+        personaConfig:
+          settings.personaConfig as unknown as AvatarPersonaConfig | null,
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 300,
         contextSnippets,
@@ -1035,8 +1036,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         aiReply = await aiService.generateReply({
           content: message.content,
           senderName: message.senderName,
-          creatorToneDescription:
-            (settings.aiSettings as any)?.creatorToneDescription || '',
+          personaConfig:
+            settings.personaConfig as unknown as AvatarPersonaConfig | null,
           temperature: (settings.aiTemperature || 70) / 100, // Default to 0.7 if null
           maxLength: settings.maxResponseLength || 500, // Default to 500 if null,
           contextSnippets: useContext ? contextSnippets : undefined,
@@ -1133,8 +1134,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const aiReply = await aiService.generateReply({
         content: message.content,
         senderName: message.senderName,
-        creatorToneDescription:
-          (settings.aiSettings as any)?.creatorToneDescription || '',
+        personaConfig:
+          settings.personaConfig as unknown as AvatarPersonaConfig | null,
         temperature: (settings.aiTemperature || 70) / 100,
         maxLength: settings.maxResponseLength || 500,
         model: settings.aiSettings?.model || 'gpt-4o',
@@ -1205,8 +1206,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const reply = await aiService.generateReply({
         content: data.content,
         senderName: data.senderName,
-        creatorToneDescription:
-          (settings.aiSettings as any)?.creatorToneDescription || '',
+        personaConfig:
+          settings.personaConfig as unknown as AvatarPersonaConfig | null,
         temperature: (settings.aiTemperature || 70) / 100, // Default to 0.7 if null
         maxLength: settings.maxResponseLength || 500, // Default to 500 if null,
         contextSnippets:
@@ -1458,7 +1459,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
       }
 
-      const { creatorToneDescription, ...settingsResponse } = settings
+      const { personaConfig, ...settingsResponse } = settings
       res.json(settingsResponse)
     } catch (error: any) {
       res.status(500).json({ message: error.message })

--- a/server/services/openai.test.ts
+++ b/server/services/openai.test.ts
@@ -1,6 +1,7 @@
 // See CHANGELOG.md for 2025-06-11 [Added]
 // See CHANGELOG.md for 2025-06-11 [Fixed-3]
 // See CHANGELOG.md for 2025-06-16 [Changed]
+// See CHANGELOG.md for 2025-06-16 [Changed-2]
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { AIService } from './openai'
 import { storage } from '../storage'
@@ -58,7 +59,7 @@ describe('AIService', () => {
     const reply = await service.generateReply({
       content: 'hi',
       senderName: 'Bob',
-      creatorToneDescription: '',
+      personaConfig: null,
       temperature: 0.5,
       maxLength: 10,
       model: 'gpt-4',
@@ -75,7 +76,7 @@ describe('AIService', () => {
     await service.generateReply({
       content: 'test',
       senderName: 'Bob',
-      creatorToneDescription: '',
+      personaConfig: null,
       temperature: 0.5,
       maxLength: 10,
       flexProcessing: true,
@@ -97,7 +98,7 @@ describe('AIService', () => {
     await service.generateReply({
       content: 'test',
       senderName: 'Bob',
-      creatorToneDescription: '',
+      personaConfig: null,
       temperature: 0.5,
       maxLength: 10,
       model: 'gpt-3.5-turbo',
@@ -135,7 +136,7 @@ describe('AIService', () => {
     await service.generateReply({
       content: 'hi',
       senderName: 'Bob',
-      creatorToneDescription: '',
+      personaConfig: persona,
       temperature: 0.5,
       maxLength: 10,
     })
@@ -170,7 +171,7 @@ describe('AIService', () => {
     await service.generateReply({
       content: 'hi',
       senderName: 'Bob',
-      creatorToneDescription: '',
+      personaConfig: null,
       temperature: 0.5,
       maxLength: 10,
     })

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -10,6 +10,7 @@
 // See CHANGELOG.md for 2025-06-12 [Changed]
 // See CHANGELOG.md for 2025-06-11 [Changed-4]
 // See CHANGELOG.md for 2025-06-16 [Changed]
+// See CHANGELOG.md for 2025-06-16 [Changed-2]
 
 // dotenv/config is imported in server/index.ts before this service is
 // instantiated, so manual .env parsing is unnecessary.
@@ -35,6 +36,7 @@ interface GenerateReplyParams {
   model?: string
   contextSnippets?: string[] // Additional context from content RAG pipeline
   flexProcessing?: boolean
+  personaConfig?: AvatarPersonaConfig | null
 }
 
 interface ClassifyIntentResult {
@@ -128,6 +130,7 @@ export class AIService {
         contextSnippets,
         flexProcessing,
         model,
+        personaConfig,
       } = params
 
       if (process.env.DEBUG_AI) {
@@ -172,16 +175,15 @@ export class AIService {
 
       let systemPrompt = settings.systemPrompt
       if (!systemPrompt) {
-        if (settings.personaConfig) {
+        const persona = personaConfig ?? settings.personaConfig
+        if (persona) {
           if (process.env.DEBUG_AI) {
             console.debug(
               '[DEBUG-AI] Persona config:',
-              JSON.stringify(settings.personaConfig, null, 2),
+              JSON.stringify(persona, null, 2),
             )
           }
-          systemPrompt = buildSystemPrompt(
-            settings.personaConfig as AvatarPersonaConfig,
-          )
+          systemPrompt = buildSystemPrompt(persona as AvatarPersonaConfig)
         } else {
           systemPrompt = DEFAULT_SYSTEM_PROMPT
         }


### PR DESCRIPTION
## Summary
- migrate all service logic to `personaConfig`
- update OpenAI tests and routes to use personaConfig
- remove legacy creatorToneDescription from storage
- regenerate system prompts using personaConfig

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685054996aa48333a807ef7c7296e2e4