### PR TITLE
Fix AvatarSettings error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,3 +239,5 @@ CHANGLOG.md file.
 
 - [Codex][Changed-2] Replaced creatorToneDescription with personaConfig across
   codebase.
+- [Codex][Fixed] AvatarSettings shows server error message on save failure.
+- [Codex][Fixed] Database status endpoint typings for type-check.

--- a/client/src/pages/settings/AvatarSettingsPage.tsx
+++ b/client/src/pages/settings/AvatarSettingsPage.tsx
@@ -36,9 +36,30 @@ export default function AvatarSettingsPage() {
           const generatedPrompt = buildSystemPrompt(data.personaConfig)
           setPrompt(generatedPrompt)
         }
+      } else {
+        try {
+          const errData = await response.json()
+          console.error(
+            'Error fetching persona config:',
+            errData.message || errData,
+          )
+          toast({
+            title: 'Error',
+            description: errData.message || 'Failed to load persona',
+            variant: 'destructive',
+          })
+        } catch (parseError) {
+          console.error(
+            'Error parsing persona fetch failure:',
+            parseError instanceof Error ? parseError.message : parseError,
+          )
+        }
       }
     } catch (error) {
-      console.error('Error fetching persona config:', error)
+      console.error(
+        'Error fetching persona config:',
+        error instanceof Error ? error.message : error,
+      )
     }
   }
 
@@ -67,15 +88,33 @@ export default function AvatarSettingsPage() {
           description: 'Persona configuration saved successfully!',
         })
       } else {
-        const error = await response.json()
-        toast({
-          title: 'Error',
-          description: `Failed to save: ${error.message}`,
-          variant: 'destructive',
-        })
+        try {
+          const errData = await response.json()
+          const message =
+            errData.message || 'Failed to save persona configuration'
+          toast({
+            title: 'Error',
+            description: message,
+            variant: 'destructive',
+          })
+          console.error('Error saving persona config:', message)
+        } catch (parseError) {
+          console.error(
+            'Error parsing persona save failure:',
+            parseError instanceof Error ? parseError.message : parseError,
+          )
+          toast({
+            title: 'Error',
+            description: 'Failed to save persona configuration',
+            variant: 'destructive',
+          })
+        }
       }
     } catch (error) {
-      console.error('Error saving persona config:', error)
+      console.error(
+        'Error saving persona config:',
+        error instanceof Error ? error.message : error,
+      )
       toast({
         title: 'Error',
         description: 'Failed to save persona configuration',

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1834,18 +1834,28 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const threads = await storage.getThreads(1)
       const instagramMessages = await storage.getInstagramMessages()
       const youtubeMessages = await storage.getYoutubeMessages()
-      
-      const status = {
+
+      const status: {
+        threadsCount: number
+        instagramMessagesCount: number
+        youtubeMessagesCount: number
+        threads: { id: number; name: string; messageCount: number }[]
+        message?: string
+      } = {
         threadsCount: threads.length,
         instagramMessagesCount: instagramMessages.length,
         youtubeMessagesCount: youtubeMessages.length,
-        threads: threads.map(t => ({ id: t.id, name: t.participantName, messageCount: 0 }))
+        threads: threads.map((t) => ({
+          id: t.id,
+          name: t.participantName,
+          messageCount: 0,
+        })),
       }
-      
+
       // If no threads exist, create some test data
       if (threads.length === 0) {
         console.log('No threads found, creating test data...')
-        
+
         // Create a few test threads with messages
         for (let i = 0; i < 3; i++) {
           const thread = await storage.findOrCreateThreadByParticipant(
@@ -1853,9 +1863,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
             `test-user-${i}`,
             `Test User ${i + 1}`,
             'instagram',
-            `https://images.unsplash.com/photo-${1500000000000 + i}?w=64&h=64`
+            `https://images.unsplash.com/photo-${1500000000000 + i}?w=64&h=64`,
           )
-          
+
           await storage.addMessageToThread(thread.id, {
             source: 'instagram',
             content: `Hello, this is test message ${i + 1}`,
@@ -1866,20 +1876,29 @@ export async function registerRoutes(app: Express): Promise<Server> {
             status: 'new',
             isHighIntent: i === 1, // Make one high intent
             userId: 1,
-            metadata: {}
+            metadata: {},
           })
         }
-        
+
         status.message = 'Created test data'
         const updatedThreads = await storage.getThreads(1)
         status.threadsCount = updatedThreads.length
-        status.threads = updatedThreads.map(t => ({ id: t.id, name: t.participantName }))
+        status.threads = updatedThreads.map((t) => ({
+          id: t.id,
+          name: t.participantName,
+          messageCount: 0,
+        }))
       }
-      
+
       res.json(status)
     } catch (error) {
-      console.error('Database status check error:', error)
-      res.status(500).json({ error: error.message })
+      console.error(
+        'Database status check error:',
+        error instanceof Error ? error.message : error,
+      )
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
     }
   })
 


### PR DESCRIPTION
## Summary
- improve AvatarSettings error logging
- display message from server on persona save failure
- type Database status endpoint to satisfy TS

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --silent=false`
- `npm outdated --depth=0`


------
https://chatgpt.com/codex/tasks/task_e_68509c5e88108333823b52079a3132da