### PR TITLE
Improve persona validation and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,3 +239,8 @@ CHANGLOG.md file.
 
 - [Codex][Changed-2] Replaced creatorToneDescription with personaConfig across
   codebase.
+
+## 2025-06-17
+
+- [Codex][Changed] Persona API schema enforces non-empty strings and arrays.
+- [Codex][Fixed] Database status check typing errors.

--- a/client/src/pages/settings/AvatarSettingsPage.tsx
+++ b/client/src/pages/settings/AvatarSettingsPage.tsx
@@ -1,5 +1,6 @@
 // See CHANGELOG.md for 2025-06-15 [Added]
 // See CHANGELOG.md for 2025-06-16 [Fixed]
+// See CHANGELOG.md for 2025-06-17 [Changed]
 import { useState, useEffect } from 'react'
 import PrivacyPersonalityForm from '@/components/PrivacyPersonalityForm'
 import { buildSystemPrompt } from '@shared/prompt'

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -2,6 +2,7 @@
 // See CHANGELOG.md for 2025-06-14 [Added]
 // See CHANGELOG.md for 2025-06-13 [Added]
 // See CHANGELOG.md for 2025-06-13 [Fixed-2]
+// See CHANGELOG.md for 2025-06-17 [Added-2]
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import express from 'express'
 import type { Server } from 'http'
@@ -218,5 +219,26 @@ describe('test routes', () => {
     expect(data.systemPrompt).toBe('p')
     const settings = await mem.getSettings(1)
     expect(settings.systemPrompt).toBe('p')
+  })
+
+  it('rejects invalid persona config', async () => {
+    const payload = {
+      personaConfig: {
+        toneDescription: '',
+        styleTags: [],
+        allowedTopics: [],
+        restrictedTopics: [],
+        fallbackReply: '',
+      },
+      systemPrompt: '',
+    }
+    const res = await fetch(`${baseUrl}/api/persona`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.message).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- enforce non-empty strings and arrays in persona API
- store messages array after seeding test data and fix typings
- expose server validation errors in tests
- document changes in changelog

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68509c6180ec833395b21a7e7ff01c5e