### PR TITLE
feat(settings): store persona presets in state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,3 +246,7 @@ CHANGLOG.md file.
 - [Codex][Fixed] AvatarSettings shows server error message on save failure.
 - [Codex][Fixed] Database status endpoint typings for type-check.
 
+## 2025-06-17
+
+- [Codex][Changed] PrivacyPersonalityForm now stores presets in state so saved
+  style tags and topics display after reloading.

--- a/client/src/components/PrivacyPersonalityForm.tsx
+++ b/client/src/components/PrivacyPersonalityForm.tsx
@@ -1,5 +1,6 @@
 // See CHANGELOG.md for 2025-06-15 [Added]
 // See CHANGELOG.md for 2025-06-16 [Changed - deeper Tone & Style textbox]
+// See CHANGELOG.md for 2025-06-17 [Changed - presets now stored in state]
 import React from 'react'
 import { useForm } from 'react-hook-form'
 import {
@@ -23,15 +24,33 @@ interface Props {
   isLoading?: boolean
 }
 
-const STYLE_OPTIONS = ['Friendly', 'Professional', 'Sarcastic', 'Humorous']
-const ALLOWED_PRESETS = ['My pets', 'Content creation', 'Travel tips']
-const RESTRICTED_PRESETS = ['Politics', 'Religion', 'Personal relationships']
+const INITIAL_STYLE_OPTIONS = [
+  'Friendly',
+  'Professional',
+  'Sarcastic',
+  'Humorous',
+]
+const INITIAL_ALLOWED_PRESETS = ['My pets', 'Content creation', 'Travel tips']
+const INITIAL_RESTRICTED_PRESETS = [
+  'Politics',
+  'Religion',
+  'Personal relationships',
+]
 
 export default function PrivacyPersonalityForm({
   onSave,
   initialConfig,
   isLoading,
 }: Props) {
+  const [styleOptions, setStyleOptions] = React.useState<string[]>(
+    INITIAL_STYLE_OPTIONS,
+  )
+  const [allowedPresets, setAllowedPresets] = React.useState<string[]>(
+    INITIAL_ALLOWED_PRESETS,
+  )
+  const [restrictedPresets, setRestrictedPresets] = React.useState<string[]>(
+    INITIAL_RESTRICTED_PRESETS,
+  )
   const form = useForm<AvatarPersonaConfig>({
     defaultValues: {
       toneDescription: initialConfig?.toneDescription || '',
@@ -45,6 +64,17 @@ export default function PrivacyPersonalityForm({
   // Update form when initialConfig changes
   React.useEffect(() => {
     if (initialConfig) {
+      setStyleOptions((prev) =>
+        Array.from(new Set([...prev, ...(initialConfig.styleTags || [])])),
+      )
+      setAllowedPresets((prev) =>
+        Array.from(new Set([...prev, ...(initialConfig.allowedTopics || [])])),
+      )
+      setRestrictedPresets((prev) =>
+        Array.from(
+          new Set([...prev, ...(initialConfig.restrictedTopics || [])]),
+        ),
+      )
       form.reset({
         toneDescription: initialConfig.toneDescription || '',
         styleTags: initialConfig.styleTags || [],
@@ -61,14 +91,20 @@ export default function PrivacyPersonalityForm({
       ...data,
       toneDescription: data.toneDescription?.trim() || '',
       styleTags: Array.isArray(data.styleTags) ? data.styleTags : [],
-      allowedTopics: Array.isArray(data.allowedTopics) ? data.allowedTopics.filter(Boolean) : [],
-      restrictedTopics: Array.isArray(data.restrictedTopics) ? data.restrictedTopics.filter(Boolean) : [],
-      fallbackReply: data.fallbackReply?.trim() || ''
+      allowedTopics: Array.isArray(data.allowedTopics)
+        ? data.allowedTopics.filter(Boolean)
+        : [],
+      restrictedTopics: Array.isArray(data.restrictedTopics)
+        ? data.restrictedTopics.filter(Boolean)
+        : [],
+      fallbackReply: data.fallbackReply?.trim() || '',
     }
 
     // Additional validation
     if (!cleanedData.toneDescription) {
-      form.setError('toneDescription', { message: 'Tone description is required' })
+      form.setError('toneDescription', {
+        message: 'Tone description is required',
+      })
       return
     }
 
@@ -77,8 +113,14 @@ export default function PrivacyPersonalityForm({
       return
     }
 
-    if (!cleanedData.fallbackReply || cleanedData.fallbackReply.trim() === '' || cleanedData.fallbackReply === 'custom') {
-      form.setError('fallbackReply', { message: 'Please provide a fallback reply' })
+    if (
+      !cleanedData.fallbackReply ||
+      cleanedData.fallbackReply.trim() === '' ||
+      cleanedData.fallbackReply === 'custom'
+    ) {
+      form.setError('fallbackReply', {
+        message: 'Please provide a fallback reply',
+      })
       return
     }
 
@@ -116,7 +158,7 @@ export default function PrivacyPersonalityForm({
             <FormItem>
               <FormLabel>Style Tags</FormLabel>
               <div className="grid grid-cols-2 gap-2 mt-2">
-                {STYLE_OPTIONS.map((opt) => (
+                {styleOptions.map((opt) => (
                   <label key={opt} className="flex items-center space-x-2">
                     <Checkbox
                       checked={form.watch('styleTags').includes(opt)}
@@ -124,7 +166,9 @@ export default function PrivacyPersonalityForm({
                         const cur = form.getValues('styleTags')
                         form.setValue(
                           'styleTags',
-                          checked ? [...cur, opt] : cur.filter((v) => v !== opt),
+                          checked
+                            ? [...cur, opt]
+                            : cur.filter((v) => v !== opt),
                         )
                       }}
                     />
@@ -146,7 +190,7 @@ export default function PrivacyPersonalityForm({
             <FormItem>
               <FormLabel>Allowed Topics</FormLabel>
               <div className="grid grid-cols-2 gap-2 mt-2">
-                {ALLOWED_PRESETS.map((topic) => (
+                {allowedPresets.map((topic) => (
                   <label key={topic} className="flex items-center space-x-2">
                     <Checkbox
                       checked={form.watch('allowedTopics').includes(topic)}
@@ -192,7 +236,7 @@ export default function PrivacyPersonalityForm({
             <FormItem>
               <FormLabel>Restricted Topics</FormLabel>
               <div className="grid grid-cols-2 gap-2 mt-2">
-                {RESTRICTED_PRESETS.map((topic) => (
+                {restrictedPresets.map((topic) => (
                   <label key={topic} className="flex items-center space-x-2">
                     <Checkbox
                       checked={form.watch('restrictedTopics').includes(topic)}
@@ -256,18 +300,26 @@ export default function PrivacyPersonalityForm({
                     <RadioGroupItem value="custom" />
                     <Input
                       placeholder="Custom response"
-                      value={field.value === "Sorry, I keep that private." || field.value === "Let's chat about something else!" ? "" : field.value}
+                      value={
+                        field.value === 'Sorry, I keep that private.' ||
+                        field.value === "Let's chat about something else!"
+                          ? ''
+                          : field.value
+                      }
                       onChange={(e) => {
                         const customValue = e.target.value
                         if (customValue.trim()) {
                           field.onChange(customValue)
                         } else {
-                          field.onChange("custom")
+                          field.onChange('custom')
                         }
                       }}
                       onFocus={() => {
-                        if (field.value === "Sorry, I keep that private." || field.value === "Let's chat about something else!") {
-                          field.onChange("")
+                        if (
+                          field.value === 'Sorry, I keep that private.' ||
+                          field.value === "Let's chat about something else!"
+                        ) {
+                          field.onChange('')
                         }
                       }}
                     />

--- a/client/src/pages/settings/AvatarSettingsPage.tsx
+++ b/client/src/pages/settings/AvatarSettingsPage.tsx
@@ -27,7 +27,6 @@ export default function AvatarSettingsPage() {
   ────────────────────────────────── */
   useEffect(() => {
     fetchPersonaConfig()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   /* ────────────────────────────────
@@ -50,7 +49,10 @@ export default function AvatarSettingsPage() {
         }
       } else {
         const errData = await response.json().catch(() => ({}))
-        console.error('Error fetching persona config:', errData.message || 'Unknown error')
+        console.error(
+          'Error fetching persona config:',
+          errData.message || 'Unknown error',
+        )
       }
     } catch (error) {
       console.error('Error fetching persona config:', error)
@@ -81,7 +83,8 @@ export default function AvatarSettingsPage() {
         })
       } else {
         const errData = await response.json().catch(() => ({}))
-        const message = errData.message || 'Failed to save persona configuration'
+        const message =
+          errData.message || 'Failed to save persona configuration'
         toast({
           title: 'Error',
           description: message,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1705,7 +1705,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }),
       })
 
-      const { personaConfig} = schema.parse(req.body)
+      const { personaConfig } = schema.parse(req.body)
       const updated = await storage.updateSettings(1, {
         personaConfig,
       })
@@ -1901,13 +1901,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       // Also force clear the persona config from database
       await storage.updateSettings(1, {
-        personaConfig: null,
-        systemPrompt: null
+        personaConfig: {},
+        systemPrompt: undefined,
       })
 
       res.json({
         success: true,
-        message: 'Cache cleared successfully'
+        message: 'Cache cleared successfully',
       })
     } catch (error: any) {
       res.status(500).json({ message: error.message })


### PR DESCRIPTION
## Summary
- preserve saved style tags and topics in PrivacyPersonalityForm by using state
- remove unused ESLint disable comment
- clear persona config without null assignment

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e1f261848333b049ba364d14843a