### PR TITLE
Fix persona reset logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,3 +246,7 @@ CHANGLOG.md file.
 - [Codex][Fixed] AvatarSettings shows server error message on save failure.
 - [Codex][Fixed] Database status endpoint typings for type-check.
 
+## 2025-06-17
+
+- [Codex][Fixed] Clearing persona resets form fields to defaults in
+  PrivacyPersonalityForm.

--- a/client/src/components/PrivacyPersonalityForm.test.tsx
+++ b/client/src/components/PrivacyPersonalityForm.test.tsx
@@ -10,4 +10,12 @@ describe('PrivacyPersonalityForm', () => {
     )
     expect(html).toContain('Save Preferences')
   })
+
+  it('shows empty fields when initialConfig is null', () => {
+    const html = renderToStaticMarkup(
+      <PrivacyPersonalityForm onSave={() => {}} initialConfig={null} />,
+    )
+    expect(html).toContain('textarea')
+    expect(html).toContain('value=""')
+  })
 })

--- a/client/src/components/PrivacyPersonalityForm.tsx
+++ b/client/src/components/PrivacyPersonalityForm.tsx
@@ -1,5 +1,6 @@
 // See CHANGELOG.md for 2025-06-15 [Added]
 // See CHANGELOG.md for 2025-06-16 [Changed - deeper Tone & Style textbox]
+// Persona logic reference: docs/stage_1_persona.md
 import React from 'react'
 import { useForm } from 'react-hook-form'
 import {
@@ -52,6 +53,15 @@ export default function PrivacyPersonalityForm({
         restrictedTopics: initialConfig.restrictedTopics || [],
         fallbackReply: initialConfig.fallbackReply || '',
       })
+    } else {
+      // Reset to empty defaults when persona is cleared
+      form.reset({
+        toneDescription: '',
+        styleTags: [],
+        allowedTopics: [],
+        restrictedTopics: [],
+        fallbackReply: '',
+      })
     }
   }, [initialConfig, form])
 
@@ -61,14 +71,20 @@ export default function PrivacyPersonalityForm({
       ...data,
       toneDescription: data.toneDescription?.trim() || '',
       styleTags: Array.isArray(data.styleTags) ? data.styleTags : [],
-      allowedTopics: Array.isArray(data.allowedTopics) ? data.allowedTopics.filter(Boolean) : [],
-      restrictedTopics: Array.isArray(data.restrictedTopics) ? data.restrictedTopics.filter(Boolean) : [],
-      fallbackReply: data.fallbackReply?.trim() || ''
+      allowedTopics: Array.isArray(data.allowedTopics)
+        ? data.allowedTopics.filter(Boolean)
+        : [],
+      restrictedTopics: Array.isArray(data.restrictedTopics)
+        ? data.restrictedTopics.filter(Boolean)
+        : [],
+      fallbackReply: data.fallbackReply?.trim() || '',
     }
 
     // Additional validation
     if (!cleanedData.toneDescription) {
-      form.setError('toneDescription', { message: 'Tone description is required' })
+      form.setError('toneDescription', {
+        message: 'Tone description is required',
+      })
       return
     }
 
@@ -77,8 +93,14 @@ export default function PrivacyPersonalityForm({
       return
     }
 
-    if (!cleanedData.fallbackReply || cleanedData.fallbackReply.trim() === '' || cleanedData.fallbackReply === 'custom') {
-      form.setError('fallbackReply', { message: 'Please provide a fallback reply' })
+    if (
+      !cleanedData.fallbackReply ||
+      cleanedData.fallbackReply.trim() === '' ||
+      cleanedData.fallbackReply === 'custom'
+    ) {
+      form.setError('fallbackReply', {
+        message: 'Please provide a fallback reply',
+      })
       return
     }
 
@@ -124,7 +146,9 @@ export default function PrivacyPersonalityForm({
                         const cur = form.getValues('styleTags')
                         form.setValue(
                           'styleTags',
-                          checked ? [...cur, opt] : cur.filter((v) => v !== opt),
+                          checked
+                            ? [...cur, opt]
+                            : cur.filter((v) => v !== opt),
                         )
                       }}
                     />
@@ -256,18 +280,26 @@ export default function PrivacyPersonalityForm({
                     <RadioGroupItem value="custom" />
                     <Input
                       placeholder="Custom response"
-                      value={field.value === "Sorry, I keep that private." || field.value === "Let's chat about something else!" ? "" : field.value}
+                      value={
+                        field.value === 'Sorry, I keep that private.' ||
+                        field.value === "Let's chat about something else!"
+                          ? ''
+                          : field.value
+                      }
                       onChange={(e) => {
                         const customValue = e.target.value
                         if (customValue.trim()) {
                           field.onChange(customValue)
                         } else {
-                          field.onChange("custom")
+                          field.onChange('custom')
                         }
                       }}
                       onFocus={() => {
-                        if (field.value === "Sorry, I keep that private." || field.value === "Let's chat about something else!") {
-                          field.onChange("")
+                        if (
+                          field.value === 'Sorry, I keep that private.' ||
+                          field.value === "Let's chat about something else!"
+                        ) {
+                          field.onChange('')
                         }
                       }}
                     />

--- a/client/src/pages/settings/AvatarSettingsPage.tsx
+++ b/client/src/pages/settings/AvatarSettingsPage.tsx
@@ -27,7 +27,6 @@ export default function AvatarSettingsPage() {
   ────────────────────────────────── */
   useEffect(() => {
     fetchPersonaConfig()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   /* ────────────────────────────────
@@ -50,7 +49,10 @@ export default function AvatarSettingsPage() {
         }
       } else {
         const errData = await response.json().catch(() => ({}))
-        console.error('Error fetching persona config:', errData.message || 'Unknown error')
+        console.error(
+          'Error fetching persona config:',
+          errData.message || 'Unknown error',
+        )
       }
     } catch (error) {
       console.error('Error fetching persona config:', error)
@@ -81,7 +83,8 @@ export default function AvatarSettingsPage() {
         })
       } else {
         const errData = await response.json().catch(() => ({}))
-        const message = errData.message || 'Failed to save persona configuration'
+        const message =
+          errData.message || 'Failed to save persona configuration'
         toast({
           title: 'Error',
           description: message,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1705,7 +1705,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }),
       })
 
-      const { personaConfig} = schema.parse(req.body)
+      const { personaConfig } = schema.parse(req.body)
       const updated = await storage.updateSettings(1, {
         personaConfig,
       })
@@ -1901,13 +1901,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       // Also force clear the persona config from database
       await storage.updateSettings(1, {
-        personaConfig: null,
-        systemPrompt: null
+        personaConfig: null as any,
+        systemPrompt: null as any,
       })
 
       res.json({
         success: true,
-        message: 'Cache cleared successfully'
+        message: 'Cache cleared successfully',
       })
     } catch (error: any) {
       res.status(500).json({ message: error.message })


### PR DESCRIPTION
## Summary
- reset persona form defaults when current config is cleared
- cover null persona case in regression test
- remove stray ESLint comment
- cast null updates to satisfy typing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e1ffc5848333a6150733da6004ac