### PR TITLE
Implement global MobileHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,3 +256,5 @@ CHANGLOG.md file.
 - [Codex][Changed] Persona tags use chip-based UI with electric blue selection.
 - [Codex][Changed] Allowed and restricted topics combined into tri-state chips.
 - [Codex][Added] Tests check rendering of new chips.
+[Codex][Changed] MobileHeader moved to App layout with optional back button.
+[Codex][Removed] ThreadedMessages no longer renders its own header.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-// See CHANGELOG.md for 2025-06-12 [Changed - remove MobileHeader]
+// See CHANGELOG.md for 2025-06-17 [Changed - global MobileHeader]
 import {
   BrowserRouter as Router,
   Routes,
@@ -10,6 +10,8 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { Toaster } from '@/components/ui/toaster'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { ThemeProvider } from '@/components/ui/theme-provider'
+import { useIsMobile } from '@/hooks/use-mobile'
+import MobileHeader from '@/components/layout/MobileHeader'
 
 import NotFound from '@/pages/not-found'
 import Instagram from '@/pages/instagram/Instagram'
@@ -30,8 +32,10 @@ import APIKeysPage from '@/pages/settings/APIKeysPage'
 import Sidebar from '@/components/layout/Sidebar'
 
 function AppLayout() {
+  const isMobile = useIsMobile()
   return (
     <div className="h-screen flex overflow-hidden">
+      {isMobile && <MobileHeader />}
       <Sidebar />
       <div className="flex flex-col w-0 flex-1 overflow-hidden">
         <Routes>
@@ -47,7 +51,10 @@ function AppLayout() {
           <Route path="/settings/persona" element={<AvatarSettingsPage />} />
           <Route path="/settings/ai" element={<AISettingsPage />} />
           <Route path="/settings/automation" element={<AutomationPage />} />
-          <Route path="/settings/notifications" element={<NotificationSettings />} />
+          <Route
+            path="/settings/notifications"
+            element={<NotificationSettings />}
+          />
           <Route path="/settings/api" element={<APIKeysPage />} />
           <Route path="/settings/testing-tools" element={<Testing />} />
           <Route path="/settings/privacy" element={<Privacy />} />

--- a/client/src/components/layout/MobileHeader.tsx
+++ b/client/src/components/layout/MobileHeader.tsx
@@ -1,11 +1,15 @@
-// See CHANGELOG.md for 2025-06-16 [Changed - mobile drawer navigation]
+// See CHANGELOG.md for 2025-06-17 [Changed - back button]
 import React, { useState } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
 import { Separator } from '@/components/ui/separator'
 import { Input } from '@/components/ui/input'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import {
   Menu,
   MessageSquare,
@@ -15,6 +19,7 @@ import {
   Lock,
   ChevronDown,
   ChevronRight,
+  ArrowLeft,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useToast } from '@/hooks/use-toast'
@@ -22,12 +27,17 @@ import { useQueryClient } from '@tanstack/react-query'
 
 const MobileHeader = () => {
   const location = useLocation()
+  const navigate = useNavigate()
   const path = location.pathname
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [customMessage, setCustomMessage] = useState('')
   const [isSheetOpen, setIsSheetOpen] = useState(false)
   const { toast } = useToast()
   const queryClient = useQueryClient()
+  const showBack =
+    typeof window !== 'undefined' &&
+    window.history.length > 1 &&
+    !['/', '/instagram', '/youtube'].includes(path)
 
   const NavItem = ({
     to,
@@ -72,7 +82,7 @@ const MobileHeader = () => {
 
   const handleSendCustomMessage = () => {
     if (!customMessage.trim()) return
-    
+
     // For now, just show a toast - you'll need to implement the actual logic
     toast({
       title: 'Custom Message',
@@ -86,7 +96,18 @@ const MobileHeader = () => {
     <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
       <div className="md:hidden fixed top-0 left-0 right-0 bg-white border-b border-neutral-200 z-10">
         <div className="flex items-center justify-between h-16 px-4">
-          <h1 className="text-lg font-semibold text-neutral-900">Avatar</h1>
+          <div className="flex items-center">
+            {showBack && (
+              <button
+                aria-label="Back"
+                onClick={() => navigate(-1)}
+                className="mr-3 p-2 rounded-md text-neutral-500 hover:text-neutral-900 hover:bg-neutral-100 focus:outline-none"
+              >
+                <ArrowLeft className="h-6 w-6" />
+              </button>
+            )}
+            <h1 className="text-lg font-semibold text-neutral-900">Avatar</h1>
+          </div>
           <SheetTrigger asChild>
             <Button
               variant="ghost"
@@ -113,7 +134,7 @@ const MobileHeader = () => {
           >
             Insights
           </NavItem>
-          
+
           {/* Collapsible Settings Section */}
           <Collapsible open={settingsOpen} onOpenChange={setSettingsOpen}>
             <CollapsibleTrigger className="flex items-center justify-between w-full px-4 py-2 text-base font-medium text-neutral-700 hover:text-neutral-900">
@@ -188,7 +209,7 @@ const MobileHeader = () => {
             Privacy Policy
           </NavItem>
         </nav>
-        
+
         {/* Custom Message Section */}
         <div className="mt-6">
           <Separator className="my-3" />

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -53,9 +53,8 @@ import {
 } from '@/components/ui/accordion'
 import { Input } from '@/components/ui/input'
 import ChatHeader from '@/components/layout/ChatHeader'
-import MobileHeader from '@/components/layout/MobileHeader'
 
-// Removed mobile headers so tools remain desktop-only
+// See CHANGELOG.md for 2025-06-17 [Removed - duplicate MobileHeader]
 
 import { ThreadType, Settings } from '@shared/schema'
 
@@ -356,7 +355,6 @@ const ThreadedMessages: React.FC = () => {
         isMobile ? 'pt-16' : 'pt-0'
       }`}
     >
-      {isMobile && <MobileHeader />}
       <div className="hidden md:block p-4 border-b border-gray-200 bg-white">
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-2xl font-bold">Messages</h1>


### PR DESCRIPTION
## Summary
- render `MobileHeader` from the main `App` layout
- add optional back button support to `MobileHeader`
- drop page-level header in `ThreadedMessages`

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test --silent=false`

------
https://chatgpt.com/codex/tasks/task_e_68515fe402fc8333a48eaf29a6d2f2cf