### PR TITLE
Fix thread ID detection in MobileHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,3 +258,4 @@ CHANGLOG.md file.
 - [Codex][Added] Tests check rendering of new chips.
 [Codex][Changed] MobileHeader moved to App layout with optional back button.
 [Codex][Removed] ThreadedMessages no longer renders its own header.
+[Codex][Fixed] Custom message menu now identifies thread via props instead of URL.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,11 @@
 import React, { useState, useEffect } from 'react'
-import { BrowserRouter as Router, Routes, Route, useLocation, Navigate } from 'react-router-dom'
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  useLocation,
+  Navigate,
+} from 'react-router-dom'
 import { queryClient } from './lib/queryClient'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { Toaster } from '@/components/ui/toaster'
@@ -28,41 +34,60 @@ import Sidebar from '@/components/layout/Sidebar'
 
 function AppLayout() {
   const isMobile = useIsMobile()
-  const location = useLocation();
+  const location = useLocation()
   const [conversationData, setConversationData] = useState<{
-    participantName?: string;
-    participantAvatar?: string;
-    platform?: string;
-    onBack?: () => void;
-  } | null>(null);
-  const [lastConversationRoute, setLastConversationRoute] = useState('/');
+    participantName?: string
+    participantAvatar?: string
+    platform?: string
+    threadId?: number
+    onBack?: () => void
+  } | null>(null)
+  const [lastConversationRoute, setLastConversationRoute] = useState('/')
 
   // Track the last conversation route when on conversation pages
   useEffect(() => {
     if (['/', '/instagram', '/youtube'].includes(location.pathname)) {
-      setLastConversationRoute(location.pathname);
+      setLastConversationRoute(location.pathname)
     }
-  }, [location.pathname]);
+  }, [location.pathname])
 
   // Determine if we're on a conversation route and have active conversation
-  const isConversationRoute = ['/', '/instagram', '/youtube'].includes(location.pathname)
+  const isConversationRoute = ['/', '/instagram', '/youtube'].includes(
+    location.pathname,
+  )
   const shouldShowConversationData = isConversationRoute && conversationData
 
   return (
     <div className="h-screen flex overflow-hidden">
       {isMobile && (
-        <MobileHeader 
-          conversationData={shouldShowConversationData ? conversationData : null}
+        <MobileHeader
+          conversationData={
+            shouldShowConversationData ? conversationData : undefined
+          }
           onBack={conversationData?.onBack}
           lastConversationRoute={lastConversationRoute}
-          key={location.pathname} 
+          key={location.pathname}
         />
       )}
       <Sidebar />
       <div className="flex flex-col w-0 flex-1 overflow-hidden">
         <Routes>
-          <Route path="/" element={<ThreadedMessages onConversationDataChange={setConversationData} />} />
-          <Route path="/instagram" element={<ThreadedMessages onConversationDataChange={setConversationData} />} />
+          <Route
+            path="/"
+            element={
+              <ThreadedMessages
+                onConversationDataChange={setConversationData}
+              />
+            }
+          />
+          <Route
+            path="/instagram"
+            element={
+              <ThreadedMessages
+                onConversationDataChange={setConversationData}
+              />
+            }
+          />
           <Route
             path="/youtube"
             element={<Navigate to="/instagram" replace />}

--- a/client/src/components/layout/MobileHeader.tsx
+++ b/client/src/components/layout/MobileHeader.tsx
@@ -32,13 +32,19 @@ interface MobileHeaderProps {
     participantName?: string
     participantAvatar?: string
     platform?: string
+    threadId?: number
   }
   onBack?: () => void
   onDeleteThread?: () => void
   lastConversationRoute?: string
 }
 
-const MobileHeader = ({ conversationData, onBack, onDeleteThread, lastConversationRoute }: MobileHeaderProps) => {
+const MobileHeader = ({
+  conversationData,
+  onBack,
+  onDeleteThread,
+  lastConversationRoute,
+}: MobileHeaderProps) => {
   const location = useLocation()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
@@ -48,12 +54,15 @@ const MobileHeader = ({ conversationData, onBack, onDeleteThread, lastConversati
   const [isSheetOpen, setIsSheetOpen] = useState(false)
 
   const currentPath = location.pathname
-  const isConversationView = ['/', '/instagram', '/youtube'].includes(currentPath)
-  const showBack = onBack || (
-    typeof window !== 'undefined' &&
-    window.history.length > 1 &&
-    !isConversationView
-  ) || (isConversationView && conversationData)
+  const isConversationView = ['/', '/instagram', '/youtube'].includes(
+    currentPath,
+  )
+  const showBack =
+    onBack ||
+    (typeof window !== 'undefined' &&
+      window.history.length > 1 &&
+      !isConversationView) ||
+    (isConversationView && conversationData)
 
   const NavItem = ({
     to,
@@ -105,31 +114,23 @@ const MobileHeader = ({ conversationData, onBack, onDeleteThread, lastConversati
         toast({
           title: 'No conversation selected',
           description: 'Please select a conversation first',
-          variant: 'destructive'
+          variant: 'destructive',
         })
         return
       }
 
-      // Find the active thread ID from the current route
-      const pathParts = currentPath.split('/')
-      let threadId = null
-      
-      // Check if we're on a conversation route with a thread ID
-      if (pathParts.includes('conversation')) {
-        const conversationIndex = pathParts.indexOf('conversation')
-        if (conversationIndex < pathParts.length - 1) {
-          threadId = pathParts[conversationIndex + 1]
-        }
-      } else if (pathParts.length > 1 && !isNaN(Number(pathParts[pathParts.length - 1]))) {
-        // Fallback: check if the last segment is a number
-        threadId = pathParts[pathParts.length - 1]
+      if (typeof window !== 'undefined' && (window as any).DEBUG_AI) {
+        console.debug('[DEBUG-AI] handleSendCustomMessage path', currentPath)
       }
+
+      const threadId = conversationData.threadId
 
       if (!threadId || isNaN(Number(threadId))) {
         toast({
           title: 'Invalid conversation',
-          description: 'Could not determine active conversation. Please make sure you are viewing a conversation.',
-          variant: 'destructive'
+          description:
+            'Could not determine active conversation. Please make sure you are viewing a conversation.',
+          variant: 'destructive',
         })
         return
       }
@@ -137,7 +138,7 @@ const MobileHeader = ({ conversationData, onBack, onDeleteThread, lastConversati
       const response = await fetch(`/api/test/generate-for-user/${threadId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: customMessage })
+        body: JSON.stringify({ content: customMessage }),
       })
 
       if (!response.ok) {
@@ -146,7 +147,7 @@ const MobileHeader = ({ conversationData, onBack, onDeleteThread, lastConversati
 
       toast({
         title: 'Message sent',
-        description: 'Custom message has been generated'
+        description: 'Custom message has been generated',
       })
 
       setCustomMessage('')
@@ -154,14 +155,15 @@ const MobileHeader = ({ conversationData, onBack, onDeleteThread, lastConversati
 
       // Invalidate queries to refresh the conversation
       queryClient.invalidateQueries({ queryKey: ['/api/threads'] })
-      queryClient.invalidateQueries({ queryKey: ['thread-messages', Number(threadId)] })
-
+      queryClient.invalidateQueries({
+        queryKey: ['thread-messages', Number(threadId)],
+      })
     } catch (error) {
       console.error('Error sending custom message:', error)
       toast({
         title: 'Error',
         description: 'Failed to send custom message',
-        variant: 'destructive'
+        variant: 'destructive',
       })
     }
   }
@@ -345,7 +347,7 @@ const MobileHeader = ({ conversationData, onBack, onDeleteThread, lastConversati
               </div>
 
               {/* Delete Thread */}
-              <button 
+              <button
                 onClick={handleDeleteThread}
                 className="flex items-center w-full px-0 py-2 text-sm text-red-600 hover:text-red-700 hover:bg-red-50 rounded-md -mx-2 px-2"
               >

--- a/client/src/pages/messages/ThreadedMessages.tsx
+++ b/client/src/pages/messages/ThreadedMessages.tsx
@@ -59,11 +59,22 @@ import ChatHeader from '@/components/layout/ChatHeader'
 import { ThreadType, Settings } from '@shared/schema'
 
 interface ThreadedMessagesProps {
-  onConversationDataChange?: (data: { participantName?: string; participantAvatar?: string; platform?: string; onBack?: () => void } | null) => void
+  onConversationDataChange?: (
+    data: {
+      participantName?: string
+      participantAvatar?: string
+      platform?: string
+      threadId?: number
+      onBack?: () => void
+    } | null,
+  ) => void
   onBack?: () => void
 }
 
-const ThreadedMessages: React.FC<ThreadedMessagesProps> = ({ onConversationDataChange, onBack }) => {
+const ThreadedMessages: React.FC<ThreadedMessagesProps> = ({
+  onConversationDataChange,
+  onBack,
+}) => {
   const [activeThreadId, setActiveThreadId] = useState<number | null>(null)
   const [hasSelectedThread, setHasSelectedThread] = useState(false)
   const [activeTab, setActiveTab] = useState<
@@ -134,9 +145,10 @@ const ThreadedMessages: React.FC<ThreadedMessagesProps> = ({ onConversationDataC
         if (onConversationDataChange) {
           onConversationDataChange({
             participantName: activeThreadData.participantName,
-            participantAvatar: activeThreadData.participantAvatar,  
+            participantAvatar: activeThreadData.participantAvatar,
             platform: activeThreadData.source,
-            onBack: handleBack
+            threadId: activeThreadId,
+            onBack: handleBack,
           })
         }
       } else {


### PR DESCRIPTION
## Summary
- pass active thread ID from ThreadedMessages to MobileHeader
- rely on that prop to send custom messages
- add DEBUG_AI logging for debugging
- document fix in CHANGELOG

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851cb92213c8333a5786cabc1134c4f