### PR TITLE
Add pgvector embeddings for content items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,3 +261,7 @@ CHANGLOG.md file.
 [Codex][Fixed] Custom message menu now identifies thread via props instead of URL.
 [Codex][Added] DesktopHeader burger menu replaces Sidebar for desktop threads.
 [Codex][Removed] Deprecated refresh tools from ThreadedMessages.
+
+## 2025-06-19
+
+- [Codex][Schema] content_items has new embedding pgvector column.

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -1,11 +1,11 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden"
-import { X } from "lucide-react"
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden'
+import { X } from 'lucide-react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 const Dialog = DialogPrimitive.Root
 
@@ -22,8 +22,8 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
     )}
     {...props}
   />
@@ -39,8 +39,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
       )}
       {...props}
     >
@@ -60,13 +60,13 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className,
     )}
     {...props}
   />
 )
-DialogHeader.displayName = "DialogHeader"
+DialogHeader.displayName = 'DialogHeader'
 
 const DialogFooter = ({
   className,
@@ -74,13 +74,13 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
     )}
     {...props}
   />
 )
-DialogFooter.displayName = "DialogFooter"
+DialogFooter.displayName = 'DialogFooter'
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -89,8 +89,8 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
     )}
     {...props}
   />
@@ -103,26 +103,11 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
 ))
 DialogDescription.displayName = DialogPrimitive.Description.displayName
-
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
-    )}
-    {...props}
-  />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
 
 export {
   Dialog,

--- a/migrations/0002_long_johnny_blaze.sql
+++ b/migrations/0002_long_johnny_blaze.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "content_items" ADD COLUMN "embedding" vector(1536) NOT NULL;--> statement-breakpoint

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -97,12 +97,8 @@
           "name": "analytics_user_id_users_id_fk",
           "tableFrom": "analytics",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -189,12 +185,8 @@
           "name": "automation_rules_user_id_users_id_fk",
           "tableFrom": "automation_rules",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -331,12 +323,8 @@
           "name": "content_items_user_id_users_id_fk",
           "tableFrom": "content_items",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -426,12 +414,8 @@
           "name": "leads_message_id_messages_id_fk",
           "tableFrom": "leads",
           "tableTo": "messages",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -439,12 +423,8 @@
           "name": "leads_user_id_users_id_fk",
           "tableFrom": "leads",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -549,12 +529,8 @@
           "name": "message_threads_user_id_users_id_fk",
           "tableFrom": "message_threads",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -714,12 +690,8 @@
           "name": "messages_thread_id_message_threads_id_fk",
           "tableFrom": "messages",
           "tableTo": "message_threads",
-          "columnsFrom": [
-            "thread_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -727,12 +699,8 @@
           "name": "messages_user_id_users_id_fk",
           "tableFrom": "messages",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -881,12 +849,8 @@
           "name": "settings_user_id_users_id_fk",
           "tableFrom": "settings",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -940,9 +904,7 @@
         "users_username_unique": {
           "name": "users_username_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "username"
-          ]
+          "columns": ["username"]
         }
       },
       "policies": {},

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "800f3832-e5a7-4127-8351-ccee40b52499",
-  "prevId": "ee98b894-3887-4c9a-bcbd-2e8ee26beb5a",
+  "id": "ec5f76d8-c151-4e09-b47c-8b2e7035e6dd",
+  "prevId": "800f3832-e5a7-4127-8351-ccee40b52499",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -246,6 +246,12 @@
         "engagement_score": {
           "name": "engagement_score",
           "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
           "primaryKey": false,
           "notNull": true
         },
@@ -803,12 +809,6 @@
         },
         "airtable_table_name": {
           "name": "airtable_table_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "creator_tone_description": {
-          "name": "creator_tone_description",
           "type": "text",
           "primaryKey": false,
           "notNull": false

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -13,6 +13,13 @@
       "when": 1750047815191,
       "tag": "0001_nebulous_elektra",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1750213603868,
+      "tag": "0002_long_johnny_blaze",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -4,6 +4,7 @@
 // See CHANGELOG.md for 2025-06-12 [Fixed]
 // See CHANGELOG.md for 2025-06-13 [Added-2]
 // See CHANGELOG.md for 2025-06-16 [Changed-2]
+// See CHANGELOG.md for 2025-06-19 [Schema]
 import {
   messages,
   users,

--- a/server/services/content.ts
+++ b/server/services/content.ts
@@ -2,6 +2,7 @@
  * Content Service
  * Handles content ingestion, processing, and embedding for the RAG pipeline
  */
+// See CHANGELOG.md for 2025-06-19 [Schema]
 
 import { db } from '../db'
 import { storage } from '../storage'
@@ -192,7 +193,7 @@ export class ContentService {
         const embedding = await aiService.generateEmbedding(chunk)
 
         // Step 3: Store content and embedding
-        const contentItem: InsertContentItem & { embedding: number[] } = {
+        const contentItem: InsertContentItem = {
           externalId: source.id,
           userId,
           contentType: source.type,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -4,6 +4,7 @@
 // See CHANGELOG.md for 2025-06-13 [Added]
 // See CHANGELOG.md for 2025-06-12 [Fixed]
 // See CHANGELOG.md for 2025-06-13 [Added-2]
+// See CHANGELOG.md for 2025-06-19 [Schema]
 import {
   messages,
   users,
@@ -80,7 +81,7 @@ export interface IStorage {
   ): Promise<Analytics>
 
   // Content methods for RAG pipeline
-  createContentItem(contentItem: any): Promise<any>
+  createContentItem(contentItem: InsertContentItem): Promise<ContentItem>
   findSimilarContent(
     userId: number,
     embedding: number[],
@@ -873,7 +874,7 @@ export class MemStorage {
 
   // Content methods
   async createContentItem(
-    contentItem: InsertContentItem & { embedding: number[] },
+    contentItem: InsertContentItem,
   ): Promise<ContentItem> {
     const id = this.contentItems.size + 1
     const item: ContentItem = { ...contentItem, id } as ContentItem

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,5 @@
 // See CHANGELOG.md for 2025-06-12 [Added]
+// See CHANGELOG.md for 2025-06-19 [Schema]
 import {
   pgTable,
   text,
@@ -8,6 +9,8 @@ import {
   timestamp,
   jsonb,
   index,
+  // pgvector support
+  vector,
 } from 'drizzle-orm/pg-core'
 import { createInsertSchema } from 'drizzle-zod'
 import { z } from 'zod'
@@ -200,6 +203,7 @@ export const contentItems = pgTable(
     content: text('content').notNull(),
     url: text('url').notNull(),
     engagementScore: integer('engagement_score').notNull(),
+    embedding: vector('embedding', { dimensions: 1536 }).notNull(),
 
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
@@ -250,9 +254,7 @@ export type InsertAnalytics = z.infer<typeof insertAnalyticsSchema>
 export type Analytics = typeof analytics.$inferSelect
 
 export type InsertContentItem = z.infer<typeof insertContentItemSchema>
-export type ContentItem = typeof contentItems.$inferSelect & {
-  embedding?: number[]
-}
+export type ContentItem = typeof contentItems.$inferSelect
 export type InsertMessageThread = z.infer<typeof insertMessageThreadSchema>
 export type MessageThread = typeof messageThreads.$inferSelect
 


### PR DESCRIPTION
## Summary
- extend `content_items` table with `embedding` pgvector
- regenerate migrations and schema types
- update storage implementations to handle embedding vectors
- fix duplicate constants in dialog UI

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_685222ecfc348333a485aeb095426ff6