### PR TITLE
Implement modular content fetchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,3 +261,4 @@ CHANGLOG.md file.
 [Codex][Fixed] Custom message menu now identifies thread via props instead of URL.
 [Codex][Added] DesktopHeader burger menu replaces Sidebar for desktop threads.
 [Codex][Removed] Deprecated refresh tools from ThreadedMessages.
+[Codex][Added] ContentService aggregates registered fetchers.

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -1,11 +1,11 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden"
-import { X } from "lucide-react"
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden'
+import { X } from 'lucide-react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 const Dialog = DialogPrimitive.Root
 
@@ -22,8 +22,8 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
     )}
     {...props}
   />
@@ -39,8 +39,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
       )}
       {...props}
     >
@@ -60,13 +60,13 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className,
     )}
     {...props}
   />
 )
-DialogHeader.displayName = "DialogHeader"
+DialogHeader.displayName = 'DialogHeader'
 
 const DialogFooter = ({
   className,
@@ -74,28 +74,13 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
     )}
     {...props}
   />
 )
-DialogFooter.displayName = "DialogFooter"
-
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
-    )}
-    {...props}
-  />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+DialogFooter.displayName = 'DialogFooter'
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -103,7 +88,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
 ))
@@ -116,8 +101,8 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
     )}
     {...props}
   />

--- a/server/services/content.test.ts
+++ b/server/services/content.test.ts
@@ -4,22 +4,55 @@ vi.mock('../storage', () => ({
   storage: {
     createContentItem: vi.fn().mockResolvedValue({}),
     findSimilarContent: vi.fn().mockResolvedValue(['a']),
-  }
+  },
 }))
-vi.mock('./openai', () => ({ aiService: { generateEmbedding: vi.fn().mockResolvedValue([0]) } }))
+vi.mock('./openai', () => ({
+  aiService: { generateEmbedding: vi.fn().mockResolvedValue([0]) },
+}))
 
-import { ContentService } from './content'
-const service = new ContentService()
+import { ContentService, ContentSourceFetcher } from './content'
 
-vi.spyOn<any, any>(service as any, 'fetchSampleContent').mockResolvedValue([
-  { id: '1', type: 'post', url: '', title: 't', content: 'c', publishedAt: new Date(), engagement: { likes: 1, comments: 1, shares: 1 } }
-])
+const fetcher1: ContentSourceFetcher = {
+  fetch: vi
+    .fn()
+    .mockResolvedValue([
+      {
+        id: '1',
+        type: 'post',
+        url: '',
+        title: 't',
+        content: 'c',
+        publishedAt: new Date(),
+        engagement: { likes: 1, comments: 1, shares: 1 },
+      },
+    ]),
+}
+
+const fetcher2: ContentSourceFetcher = {
+  fetch: vi
+    .fn()
+    .mockResolvedValue([
+      {
+        id: '2',
+        type: 'video',
+        url: '',
+        title: 't2',
+        content: 'c2',
+        publishedAt: new Date(),
+        engagement: { likes: 2, comments: 2, shares: 2 },
+      },
+    ]),
+}
+
+const service = new ContentService([fetcher1, fetcher2])
 
 describe('ContentService', () => {
   it('ingestContent processes content', async () => {
     const res = await service.ingestContent(1, true)
     expect(res.success).toBe(true)
-    expect(res.processed).toBe(1)
+    expect(res.processed).toBe(2)
+    expect(fetcher1.fetch).toHaveBeenCalled()
+    expect(fetcher2.fetch).toHaveBeenCalled()
   })
 
   it('retrieveRelevantContent returns content', async () => {

--- a/server/services/content.ts
+++ b/server/services/content.ts
@@ -24,7 +24,94 @@ interface ContentSource {
   }
 }
 
+export interface ContentSourceFetcher {
+  fetch(userId: number, since: Date): Promise<ContentSource[]>
+}
+
+export class MockContentFetcher implements ContentSourceFetcher {
+  async fetch(userId: number, since: Date): Promise<ContentSource[]> {
+    // For development: Generate some sample content
+    return [
+      {
+        id: `post_${Date.now()}_1`,
+        type: 'post',
+        url: 'https://instagram.com/p/sample1',
+        title: 'Amazing encounter with sea turtles today!',
+        content:
+          "Had the most incredible dive today and encountered a family of green sea turtles! These magnificent creatures can live over 80 years and travel thousands of miles across oceans. Did you know that sea turtles use Earth's magnetic field to navigate? They return to the exact beach where they were born to lay their eggs. It's absolutely mind-blowing how they remember their birthplace after decades in the ocean. Conservation efforts are crucial - always maintain distance and never touch marine wildlife!",
+        publishedAt: new Date(),
+        engagement: {
+          likes: 1200,
+          comments: 150,
+          shares: 45,
+        },
+      },
+      {
+        id: `video_${Date.now()}_1`,
+        type: 'video',
+        url: 'https://youtube.com/watch?v=sample1',
+        title: 'The Secret Lives of Octopuses - Intelligence Underwater',
+        content:
+          "Octopuses are among the most intelligent invertebrates on Earth! In today's video, I explore their incredible problem-solving abilities and camouflage skills. These eight-armed wonders have three hearts, blue blood, and can change both color and texture in milliseconds. I've observed them using tools, solving mazes, and even showing what appears to be playful behavior. The mimic octopus can imitate over 15 different species! Their intelligence rivals that of many vertebrates, yet they live only 1-2 years. It's a reminder of how diverse and fascinating ocean life truly is.",
+        publishedAt: new Date(),
+        engagement: {
+          likes: 3500,
+          comments: 420,
+          shares: 210,
+        },
+      },
+      {
+        id: `blog_${Date.now()}_1`,
+        type: 'blog',
+        url: 'https://myblog.com/sample1',
+        title: 'The Mysterious World of Deep Sea Creatures',
+        content:
+          "The deep ocean is Earth's final frontier, home to creatures that seem like they're from another planet. Bioluminescent jellyfish create living light shows in the darkness, while giant tube worms thrive around volcanic vents without sunlight. The vampire squid isn't actually a squid or vampire - it's a unique cephalopod that can turn itself inside out when threatened! Anglerfish use their glowing lure to attract prey in the pitch-black depths. These adaptations showcase millions of years of evolution in extreme conditions. Every deep-sea expedition reveals new species, reminding us how much we still don't know about our own planet.",
+        publishedAt: new Date(),
+        engagement: {
+          likes: 890,
+          comments: 75,
+          shares: 120,
+        },
+      },
+    ]
+  }
+}
+
+export class InstagramPostFetcher implements ContentSourceFetcher {
+  async fetch(userId: number, since: Date): Promise<ContentSource[]> {
+    log(`Fetching Instagram posts since ${since.toISOString()}`)
+    // TODO: integrate with Instagram API
+    return []
+  }
+}
+
+export class YouTubeVideoFetcher implements ContentSourceFetcher {
+  async fetch(userId: number, since: Date): Promise<ContentSource[]> {
+    log(`Fetching YouTube videos since ${since.toISOString()}`)
+    // TODO: integrate with YouTube API
+    return []
+  }
+}
+
+export class RSSContentFetcher implements ContentSourceFetcher {
+  async fetch(userId: number, since: Date): Promise<ContentSource[]> {
+    log(`Fetching RSS/blog posts since ${since.toISOString()}`)
+    // TODO: integrate with RSS feed reader
+    return []
+  }
+}
+
 export class ContentService {
+  private fetchers: ContentSourceFetcher[]
+
+  constructor(fetchers: ContentSourceFetcher[] = [new MockContentFetcher()]) {
+    this.fetchers = fetchers
+  }
+
+  registerFetcher(fetcher: ContentSourceFetcher) {
+    this.fetchers.push(fetcher)
+  }
   /**
    * Ingests and processes new content from various sources
    * @param userId The user ID to ingest content for
@@ -39,9 +126,11 @@ export class ContentService {
         ? new Date(0)
         : await this.getLastIngestionDate(userId)
 
-      // For Phase 1: Simulate content sources
-      // In production, these would be API calls to Instagram, YouTube, etc.
-      const sources = await this.fetchSampleContent(userId, lastIngestedDate)
+      const sources: ContentSource[] = []
+      for (const fetcher of this.fetchers) {
+        const fetched = await fetcher.fetch(userId, lastIngestedDate)
+        sources.push(...fetched)
+      }
 
       // Step 2: Filter content by engagement
       const highEngagementContent = this.filterByEngagement(sources)
@@ -89,61 +178,6 @@ export class ContentService {
       .limit(1)
 
     return latestItem?.timestamp || new Date(0)
-  }
-
-  /**
-   * Fetch sample content for development purposes
-   * In production, this would fetch from actual creator platforms
-   */
-  private async fetchSampleContent(
-    userId: number,
-    lastIngestedDate: Date,
-  ): Promise<ContentSource[]> {
-    // For development: Generate some sample content
-    return [
-      {
-        id: `post_${Date.now()}_1`,
-        type: 'post',
-        url: 'https://instagram.com/p/sample1',
-        title: 'Amazing encounter with sea turtles today!',
-        content:
-          "Had the most incredible dive today and encountered a family of green sea turtles! These magnificent creatures can live over 80 years and travel thousands of miles across oceans. Did you know that sea turtles use Earth's magnetic field to navigate? They return to the exact beach where they were born to lay their eggs. It's absolutely mind-blowing how they remember their birthplace after decades in the ocean. Conservation efforts are crucial - always maintain distance and never touch marine wildlife!",
-        publishedAt: new Date(),
-        engagement: {
-          likes: 1200,
-          comments: 150,
-          shares: 45,
-        },
-      },
-      {
-        id: `video_${Date.now()}_1`,
-        type: 'video',
-        url: 'https://youtube.com/watch?v=sample1',
-        title: 'The Secret Lives of Octopuses - Intelligence Underwater',
-        content:
-          "Octopuses are among the most intelligent invertebrates on Earth! In today's video, I explore their incredible problem-solving abilities and camouflage skills. These eight-armed wonders have three hearts, blue blood, and can change both color and texture in milliseconds. I've observed them using tools, solving mazes, and even showing what appears to be playful behavior. The mimic octopus can imitate over 15 different species! Their intelligence rivals that of many vertebrates, yet they live only 1-2 years. It's a reminder of how diverse and fascinating ocean life truly is.",
-        publishedAt: new Date(),
-        engagement: {
-          likes: 3500,
-          comments: 420,
-          shares: 210,
-        },
-      },
-      {
-        id: `blog_${Date.now()}_1`,
-        type: 'blog',
-        url: 'https://myblog.com/sample1',
-        title: 'The Mysterious World of Deep Sea Creatures',
-        content:
-          "The deep ocean is Earth's final frontier, home to creatures that seem like they're from another planet. Bioluminescent jellyfish create living light shows in the darkness, while giant tube worms thrive around volcanic vents without sunlight. The vampire squid isn't actually a squid or vampire - it's a unique cephalopod that can turn itself inside out when threatened! Anglerfish use their glowing lure to attract prey in the pitch-black depths. These adaptations showcase millions of years of evolution in extreme conditions. Every deep-sea expedition reveals new species, reminding us how much we still don't know about our own planet.",
-        publishedAt: new Date(),
-        engagement: {
-          likes: 890,
-          comments: 75,
-          shares: 120,
-        },
-      },
-    ]
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `ContentSourceFetcher` interface with several fetcher stubs
- update `ContentService` to use registered fetchers
- fix duplicated `DialogTitle` in dialog component
- test that multiple fetchers aggregate correctly

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685222edc4388333b0388216a902229c