### PR TITLE
Extend cache clear method and improve test cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,3 +271,8 @@ CHANGLOG.md file.
 
 - [Codex][Fixed] Persona restrictedTopics schema uses z.string().min for validation.
 
+## 2025-06-19
+
+- [Codex][Changed] `clearSystemPromptCache` now returns a boolean for cache status.
+- [Codex][Added] `GPTTraitTester` logs cleanup responses and throws on cache clear failure.
+

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -11,6 +11,7 @@
 // See CHANGELOG.md for 2025-06-11 [Changed-4]
 // See CHANGELOG.md for 2025-06-16 [Changed]
 // See CHANGELOG.md for 2025-06-16 [Changed-2]
+// See CHANGELOG.md for 2025-06-19 [Changed]
 
 // dotenv/config is imported in server/index.ts before this service is
 // instantiated, so manual .env parsing is unnecessary.
@@ -82,19 +83,22 @@ export class AIService {
 
   /**
    * Clears the system prompt cache for a specific user or all users
+   * Returns true if an entry was removed. See docs/specs/implemented/stage_1_persona.md
    */
-  clearSystemPromptCache(userId?: number): void {
+  clearSystemPromptCache(userId?: number): boolean {
     if (userId) {
-      this.systemPromptCache.delete(userId)
+      const cleared = this.systemPromptCache.delete(userId)
       if (process.env.DEBUG_AI) {
-        console.debug(`[DEBUG-AI] Cleared system prompt cache for user ${userId}`)
+        console.debug(`[DEBUG-AI] Cleared system prompt cache for user ${userId}: ${cleared}`)
       }
-    } else {
-      this.systemPromptCache.clear()
-      if (process.env.DEBUG_AI) {
-        console.debug('[DEBUG-AI] Cleared all system prompt cache')
-      }
+      return cleared
     }
+    const hadEntries = this.systemPromptCache.size > 0
+    this.systemPromptCache.clear()
+    if (process.env.DEBUG_AI) {
+      console.debug('[DEBUG-AI] Cleared all system prompt cache', { cleared: hadEntries })
+    }
+    return hadEntries
   }
 
   /**


### PR DESCRIPTION
## Summary
- return whether cache entries were removed in `clearSystemPromptCache`
- log cleanup endpoint result in `GPTTraitTester` and throw on failure
- document the changes in `CHANGELOG.md`

## Testing
- `npm run lint`
- `npm run type-check` *(fails: various TypeScript errors)*
- `npm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_6859a8264c048333b051ede778ddab8d